### PR TITLE
fix infinite loop on write timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
  - Wait a maximum of 10s for any locks before bailing and printing to stdout
  - Add a `Flush` method to the logger so we can wait for all messages to be sent
  - Add a timestamp to logs that timeout and get written to stdout
+ - Fix `tcp write i/o timeout` causing an infinite loop in `writeToLogEntries`

--- a/le.go
+++ b/le.go
@@ -394,6 +394,7 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 		if err != nil {
 			log.Printf("Error in write call: %s", err.Error())
 			log.Printf("Wanted to log: %s", s)
+			return
 		}
 
 		if l._testWaitForWrite != nil {


### PR DESCRIPTION
if the write timed out because of an io timeout then the loop would fail infinitely and the cpu maxes out on the repo running this