### PR TITLE
Change fmt to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
  - Add a `Flush` method to the logger so we can wait for all messages to be sent
  - Add a timestamp to logs that timeout and get written to stdout
  - Fix `tcp write i/o timeout` causing an infinite loop in `writeToLogEntries`
+ - Use log instead of fmt library to print to stdout

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/SpalkLtd/le_go
+
+go 1.18

--- a/le.go
+++ b/le.go
@@ -166,7 +166,7 @@ func (logger *Logger) Flags() int {
 func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 	defer func() {
 		if re := recover(); re != nil {
-			fmt.Printf("Panicked in logger.output %v\n", re)
+			log.Printf("Panicked in logger.output %v\n", re)
 			debug.PrintStack()
 			panic(re)
 		}
@@ -177,7 +177,7 @@ func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 	select {
 	case <-l.mu:
 	case <-time.After(l.writeTimeout):
-		fmt.Printf("Timedout waiting for logger.mu, wanted to log: %s", s)
+		log.Printf("Timedout waiting for logger.mu, wanted to log: %s", s)
 		l._testTimedoutWrite()
 		return
 	}
@@ -194,7 +194,7 @@ func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 		select {
 		case <-l.mu:
 		case <-time.After(l.writeTimeout):
-			fmt.Printf("Timedout waiting for logger.mu after getting caller info, wanted to log: %s", s)
+			log.Printf("Timedout waiting for logger.mu after getting caller info, wanted to log: %s", s)
 			l._testTimedoutWrite()
 			return
 		}
@@ -362,7 +362,7 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 	case <-l.writeLock:
 	case <-time.After(l.writeTimeout):
 		//Bail out here
-		fmt.Printf("%s: Timedout waiting for logging writelock: wanted to log: %s", time.Now().UTC(), s)
+		log.Printf("%s: Timedout waiting for logging writelock: wanted to log: %s", time.Now().UTC(), s)
 		l._testTimedoutWrite()
 		return
 	}


### PR DESCRIPTION
This makes it so that logs that have failed to be sent out can be redirected to another source through setting `log.SetOutput`