### PR TITLE
- Add concurrentWrites param to limit the maximum number of goroutines active at a time; - Add `errOutput` param to allow users to direct errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
  - Add a `Flush` method to the logger so we can wait for all messages to be sent
  - Add a timestamp to logs that timeout and get written to stdout
  - Fix `tcp write i/o timeout` causing an infinite loop in `writeToLogEntries`
+ - Add concurrentWrites param to limit the maximum number of goroutines active logging at a time
+ - Add `errOutput` param to allow users to direct errors


### PR DESCRIPTION
This is in preparation to allow synchroniser to properly log all logs to disk, and add an upperbound to the logging goroutines so we don't use up all CPU