### PR TITLE
Add `calldepthOffset` param to allow users to change the calldepth that is logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
  - ~Use log instead of fmt library to print to stdout~
  - Add concurrentWrites param to limit the maximum number of goroutines active logging at a time
  - Add `errOutput` param to allow users to direct errors
+ - Add `calldepthOffset` param to allow users to change the calldepth that is logged

--- a/le.go
+++ b/le.go
@@ -179,7 +179,7 @@ func (logger *Logger) Flags() int {
 // Logger. A newline is appended if the last character of s is not
 // already a newline. Calldepth is used to recover the PC and is
 // provided for generality, although at the moment on all pre-defined
-// paths it will be 3.
+// paths it will be 3 plus a given offset.
 // Output does the actual writing to the TCP connection
 func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 	log.Println("----------- le_go Output start!")

--- a/le_test.go
+++ b/le_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestConnectOpensConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil)
+	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestConnectOpensConnection(t *testing.T) {
 }
 
 func TestConnectSetsToken(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil)
+	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestConnectSetsToken(t *testing.T) {
 }
 
 func TestCloseClosesConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil)
+	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestCloseClosesConnection(t *testing.T) {
 }
 
 func TestOpenConnectionOpensConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil)
+	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestOpenConnectionOpensConnection(t *testing.T) {
 }
 
 func TestEnsureOpenConnectionDoesNothingOnOpenConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil)
+	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestEnsureOpenConnectionDoesNothingOnOpenConnection(t *testing.T) {
 }
 
 func TestEnsureOpenConnectionCreatesNewConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil)
+	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestEnsureOpenConnectionCreatesNewConnection(t *testing.T) {
 }
 
 func TestFlagsReturnsFlag(t *testing.T) {
-	le := newEmptyLogger("", "")
+	le := newEmptyLogger("", "", 0)
 	le.flag = 2
 
 	if le.Flags() != 2 {
@@ -110,7 +110,7 @@ func TestFlagsReturnsFlag(t *testing.T) {
 }
 
 func TestSetFlagsSetsFlag(t *testing.T) {
-	le := newEmptyLogger("", "")
+	le := newEmptyLogger("", "", 0)
 	le.flag = 2
 
 	le.SetFlags(1)
@@ -121,7 +121,7 @@ func TestSetFlagsSetsFlag(t *testing.T) {
 }
 
 func TestPrefixReturnsPrefix(t *testing.T) {
-	le := newEmptyLogger("", "")
+	le := newEmptyLogger("", "", 0)
 	le.prefix = "myPrefix"
 
 	if le.Prefix() != "myPrefix" {
@@ -130,7 +130,7 @@ func TestPrefixReturnsPrefix(t *testing.T) {
 }
 
 func TestSetPrefixSetsPrefix(t *testing.T) {
-	le := newEmptyLogger("", "")
+	le := newEmptyLogger("", "", 0)
 	le.prefix = "myPrefix"
 
 	le.SetPrefix("myNewPrefix")
@@ -141,7 +141,7 @@ func TestSetPrefixSetsPrefix(t *testing.T) {
 }
 
 func TestLoggerImplementsWriterInterface(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil)
+	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestLoggerImplementsWriterInterface(t *testing.T) {
 }
 
 func TestReplaceNewline(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil)
+	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestReplaceNewline(t *testing.T) {
 }
 
 func TestAddNewline(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil)
+	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestAddNewline(t *testing.T) {
 }
 
 func TestCanSendMoreThan64k(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil)
+	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func TestCanSendMoreThan64k(t *testing.T) {
 }
 
 func TestTimeoutWrites(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil)
+	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func TestTimeoutWrites(t *testing.T) {
 }
 
 func TestLimitedConcurrentWrites(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 3, io.Discard)
+	le, err := Connect("data.logentries.com:443", "myToken", 3, io.Discard, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func (f *fakeAddr) Network() string { return "" }
 func (f *fakeAddr) String() string  { return "" }
 
 func ExampleLogger() {
-	le, err := Connect("data.logentries.com:443", "XXXX-XXXX-XXXX-XXXX", 0, os.Stderr) // replace with token
+	le, err := Connect("data.logentries.com:443", "XXXX-XXXX-XXXX-XXXX", 0, os.Stderr, 0) // replace with token
 	if err != nil {
 		panic(err)
 	}
@@ -374,7 +374,7 @@ func ExampleLogger() {
 }
 
 func ExampleLogger_write() {
-	le, err := Connect("data.logentries.com:443", "XXXX-XXXX-XXXX-XXXX", 0, os.Stderr) // replace with token
+	le, err := Connect("data.logentries.com:443", "XXXX-XXXX-XXXX-XXXX", 0, os.Stderr, 0) // replace with token
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
PR 1 of 4 to get fix synch's logging:
```
	1. upgrade le_go
	2. upgrade slogger (use new le_go)
	3. upgrade LS (use new le_go and new slogger)
	4. upgrade synch (use new LS, new le_go, and new slogger)
```

### Example 

Here's a test I ran with Synch using the calldepthOffset of 1. This means that we log with calldepth of 3 + 1 (`main.go:118`).
```
----------- le_go Output start!
11:09:56.782873 le.go:216: main.go:118                    # Stack trace index: 4
11:09:56.782880 le.go:216: logger.go:145                  # Stack trace index: 3
11:09:56.782894 le.go:216: teeLogger.go:63                # Stack trace index: 2
11:09:56.782898 le.go:216: le.go:297                      # Stack trace index: 1
11:09:56.782900 le.go:216: le.go:214                      # Stack trace index: 0
11:09:56.782902 le.go:219: chosen call depth: 4
11:09:56.782906 le.go:222: main.go:118                    # Stack trace index: 4
```

Here's a test I ran with LS using calldepthOffset of 0. This means that we log with a calldepth of 3 (`middleware.go:306`).
```
2023/09/01 10:59:57 ----------- le_go Output start!
2023/09/01 10:59:57 value.go:556                   # Stack trace index: 4
2023/09/01 10:59:57 middleware.go:306              # Stack trace index: 3
2023/09/01 10:59:57 logger.go:150                  # Stack trace index: 2
2023/09/01 10:59:57 le.go:297                      # Stack trace index: 1
2023/09/01 10:59:57 le.go:214                      # Stack trace index: 0
2023/09/01 10:59:57 chosen call depth: 3
2023/09/01 10:59:57 middleware.go:306              # Stack trace index: 3
```