### PR TITLE
Rewrite logger as single-consumer pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
  - Add retries 
+ - Rewrote le_go: async channel for Print, direct connMu for Write, TryLock-bounded for Fatal/Panic. Fixes goroutine fan-out, chunk truncation, connection storm, async Fatal/Panic. See package godoc for behavior changes.

--- a/fake_server_test.go
+++ b/fake_server_test.go
@@ -1,0 +1,265 @@
+package le_go
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"strings"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeLogentriesServer struct {
+	listener  net.Listener
+	tlsConfig *tls.Config
+	addr      string
+
+	mu    sync.Mutex
+	lines []string
+	conns []net.Conn
+
+	connCount atomic.Int64
+
+	readDelayAtomic atomic.Int64
+	rejectConns     atomic.Bool
+	closeMidRead    atomic.Bool
+
+	wg     sync.WaitGroup
+	closed atomic.Bool
+}
+
+func (s *fakeLogentriesServer) SetReadDelay(d time.Duration) {
+	s.readDelayAtomic.Store(int64(d))
+}
+
+func (s *fakeLogentriesServer) getReadDelay() time.Duration {
+	return time.Duration(s.readDelayAtomic.Load())
+}
+
+func newFakeLogentriesServer(t *testing.T) *fakeLogentriesServer {
+	t.Helper()
+
+	tlsConfig := generateTLSConfig(t)
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfig)
+	if err != nil {
+		t.Fatalf("failed to start fake server: %v", err)
+	}
+
+	s := &fakeLogentriesServer{
+		listener:  listener,
+		tlsConfig: tlsConfig,
+		addr:      listener.Addr().String(),
+	}
+
+	s.wg.Add(1)
+	go s.acceptLoop()
+
+	return s
+}
+
+func (s *fakeLogentriesServer) acceptLoop() {
+	defer s.wg.Done()
+
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if s.closed.Load() {
+				return
+			}
+			continue
+		}
+
+		s.connCount.Add(1)
+
+		if s.rejectConns.Load() {
+			conn.Close()
+			continue
+		}
+
+		s.mu.Lock()
+		s.conns = append(s.conns, conn)
+		s.mu.Unlock()
+
+		s.wg.Add(1)
+		go s.handleConn(conn)
+	}
+}
+
+func (s *fakeLogentriesServer) handleConn(conn net.Conn) {
+	defer s.wg.Done()
+
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		if s.closed.Load() {
+			return
+		}
+
+		if d := s.getReadDelay(); d > 0 {
+			time.Sleep(d)
+		}
+
+		line := scanner.Text()
+		s.mu.Lock()
+		s.lines = append(s.lines, line)
+		s.mu.Unlock()
+
+		if s.closeMidRead.Load() {
+			conn.Close()
+			return
+		}
+	}
+}
+
+func (s *fakeLogentriesServer) Lines() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]string, len(s.lines))
+	copy(result, s.lines)
+	return result
+}
+
+func (s *fakeLogentriesServer) ConnectionCount() int {
+	return int(s.connCount.Load())
+}
+
+func (s *fakeLogentriesServer) Close() {
+	s.closed.Store(true)
+	s.listener.Close()
+
+	s.mu.Lock()
+	for _, c := range s.conns {
+		c.Close()
+	}
+	s.mu.Unlock()
+
+	s.wg.Wait()
+}
+
+func connectToFakeServer(t *testing.T, s *fakeLogentriesServer, concurrentWrites int, errOutput interface{ Write([]byte) (int, error) }, opts ...Option) *Logger {
+	t.Helper()
+
+	capacity := concurrentWrites
+	if capacity <= 0 {
+		capacity = 4096
+	}
+
+	l := &Logger{
+		host:            s.addr,
+		token:           "test-token",
+		calldepthOffset: 0,
+		writeTimeout:    defaultWriteTimeout,
+		dialTimeout:     defaultDialTimeout,
+		ch:              make(chan entry, capacity),
+		done:            make(chan struct{}),
+		exited:          make(chan struct{}),
+		lastRefreshAt:   time.Now(),
+		tlsConfig:       &tls.Config{InsecureSkipVerify: true},
+		_testDropped:    func(DropReason) {},
+	}
+
+	if errOutput != nil {
+		l.errOutput = errOutput
+	} else {
+		l.errOutput = &discardWriter{}
+	}
+
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	conn, err := tls.Dial("tcp", s.addr, l.tlsConfig)
+	if err != nil {
+		t.Fatalf("failed to connect to fake server: %v", err)
+	}
+	l.conn = conn
+	l.lastRefreshAt = time.Now()
+
+	go l.run()
+	return l
+}
+
+type discardWriter struct{}
+
+func (d *discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func generateTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"Test"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("failed to load key pair: %v", err)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+}
+
+func waitForLines(t *testing.T, s *fakeLogentriesServer, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(s.Lines()) >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d lines, got %d", n, len(s.Lines()))
+}
+
+func waitForConnections(t *testing.T, s *fakeLogentriesServer, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s.ConnectionCount() >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d connections, got %d", n, s.ConnectionCount())
+}
+
+func stripTokenAndHeader(line, token string) string {
+	prefix := token + " "
+	if !strings.HasPrefix(line, prefix) {
+		return line
+	}
+	return line[len(prefix):]
+}

--- a/le.go
+++ b/le.go
@@ -1,351 +1,611 @@
 // Package le_go provides a Golang client library for logging to
-// logentries.com over a TCP connection.
+// logentries.com over a TLS connection using an access token.
 //
-// it uses an access token for sending log events.
+// # Architecture
+//
+// Print-family methods (Print, Printf, Println) dispatch log entries
+// asynchronously via a bounded channel to a single consumer goroutine.
+// When the channel is full, entries are dropped and counted (see Stats).
+// Within the Print path, FIFO ordering is guaranteed.
+//
+// Write (io.Writer), Fatal, and Panic use a direct synchronous path
+// that acquires the connection mutex independently of the Print queue.
+// Write is decoupled from Print queue depth. Fatal and Panic use a
+// bounded TryLock (500ms) to avoid blocking the crash path.
+//
+// # Behavior changes from prior versions
+//
+//   - Write now prepends the access token and appends a trailing newline.
+//     Previously Write was a raw passthrough to the TCP connection.
+//   - Write now chunks payloads exceeding 65000 bytes, consistent with Print.
+//   - Fatal and Panic are synchronous in the caller goroutine. Fatal writes
+//     before os.Exit; Panic panics in the caller's stack frame (recoverable
+//     via defer recover). Previously both ran asynchronously in detached
+//     goroutines.
+//   - Under sustained connection-mutex contention, Fatal/Panic may exit or
+//     panic without writing the log message. See Stats().DroppedSyncLock.
+//   - Close is idempotent (second call returns nil) and blocks until the
+//     async queue is drained.
+//   - Write and Flush return ErrLoggerClosed after Close.
+//   - Print calls that race with Close may be silently dropped. For
+//     guaranteed delivery before shutdown, call Flush() and check its
+//     error return before calling Close().
+//   - Connection reuse now works correctly beyond 15 minutes of process
+//     uptime (fixes a connection-storm bug in prior versions).
+//   - Half-open TCP detection uses OS-level keepalive (30s period) instead
+//     of a per-call application-level read probe. Middleboxes may swallow
+//     keepalive probes; keep writeTimeout short for backup detection.
+//   - errOutput no longer emits "Timedout waiting for logger.mu" diagnostics;
+//     the mu-timeout path has been removed.
+//   - On retry after partial TCP write, Write may under-report bytes written.
+//   - errOutput should be non-blocking; a slow errOutput writer blocks all
+//     log paths.
+//   - Flush() now returns error (previously void). Existing callers that
+//     discarded the return continue to compile.
+//   - The concurrentWrites parameter to Connect now controls the channel
+//     buffer capacity rather than a goroutine semaphore. When 0, defaults
+//     to 4096.
 package le_go
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"os"
 	"runtime"
-	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// Logger represents a Logentries logger,
-// it holds the open TCP connection, access token, prefix and flags.
-//
-// all Logger operations are thread safe and blocking,
-// log operations can be invoked in a non-blocking way by calling them from
-// a goroutine.
+var ErrLoggerClosed = errors.New("le_go: logger is closed")
+
+type DropReason int
+
+const (
+	DropQueueFull DropReason = iota
+	DropClosed
+	DropSyncLock
+)
+
+type Stats struct {
+	DroppedQueueFull uint64
+	DroppedClosed    uint64
+	DroppedSyncLock  uint64
+	PanicsRecovered  uint64
+}
+
+type Option func(*Logger)
+
+type entry struct {
+	s          string
+	file       string
+	prefix     string
+	now        time.Time
+	line       int
+	flag       int
+	numRetries int
+
+	flush bool
+	ack   chan error
+}
+
 type Logger struct {
-	conn               net.Conn
-	flag               int
-	mu                 chan struct{}
-	writeLock          chan struct{}
-	concurrentWrites   chan struct{} //limit the goroutines waiting to write
-	calldepthOffset    int
-	prefix             string
-	host               string
-	token              string
-	buf                []byte
-	lastRefreshAt      time.Time
-	writeTimeout       time.Duration
-	_testWaitForWrite  *sync.WaitGroup
-	_testTimedoutWrite func()
-	wg                 *sync.WaitGroup
-	errOutput          io.Writer
-	errOutputMutex     *sync.RWMutex
-	numRetries         int
+	cfgMu      sync.Mutex
+	flag       int
+	prefix     string
+	numRetries int
+
+	host            string
+	token           string
+	calldepthOffset int
+	writeTimeout    time.Duration
+	dialTimeout     time.Duration
+	tlsConfig       *tls.Config
+
+	errOutputMutex sync.Mutex
+	errOutput      io.Writer
+
+	ch      chan entry
+	done    chan struct{}
+	exited  chan struct{}
+	closed  atomic.Bool
+	droppedQueueFull atomic.Uint64
+	droppedClosed    atomic.Uint64
+	droppedSyncLock  atomic.Uint64
+	panicsRecovered  atomic.Uint64
+
+	connMu        sync.Mutex
+	conn          net.Conn
+	lastRefreshAt time.Time
+
+	_testWaitForWrite *sync.WaitGroup
+	_testDropped      func(DropReason)
 }
 
 const lineSep = "\n"
-const maxLogLength int = 65000 //add 535 chars of headroom for the filename, timestamp and header
+const maxLogLength int = 65000
+const retryBackoff = 100 * time.Millisecond
+const fatalLockWait = 500 * time.Millisecond
+const maxConsecutivePanics = 10
+
 var defaultWriteTimeout = 10 * time.Second
+var defaultDialTimeout = 10 * time.Second
 
-// Connect creates a new Logger instance and opens a TCP connection to
-// logentries.com,
-// The token can be generated at logentries.com by adding a new log,
-// choosing manual configuration and token based TCP connection.
-func Connect(host, token string, concurrentWrites int, errOutput io.Writer, calldepthOffset int) (*Logger, error) {
-	logger := newEmptyLogger(host, token, calldepthOffset)
-	if concurrentWrites > 0 {
-		logger.concurrentWrites = make(chan struct{}, concurrentWrites)
-		for i := 0; i < concurrentWrites; i++ {
-			logger.concurrentWrites <- struct{}{}
-		}
+// Connect creates a new Logger instance and opens a TLS connection.
+// The concurrentWrites parameter controls the async channel buffer capacity;
+// 0 defaults to 4096. Optional Option values configure test hooks and timeouts.
+func Connect(host, token string, concurrentWrites int, errOutput io.Writer, calldepthOffset int, opts ...Option) (*Logger, error) {
+	capacity := concurrentWrites
+	if capacity <= 0 {
+		capacity = 4096
 	}
+
+	l := &Logger{
+		host:            host,
+		token:           token,
+		calldepthOffset: calldepthOffset,
+		writeTimeout:    defaultWriteTimeout,
+		dialTimeout:     defaultDialTimeout,
+		ch:              make(chan entry, capacity),
+		done:            make(chan struct{}),
+		exited:          make(chan struct{}),
+		lastRefreshAt:   time.Now(),
+		_testDropped:    func(DropReason) {},
+	}
+
 	if errOutput != nil {
-		logger.errOutput = errOutput
+		l.errOutput = errOutput
 	} else {
-		logger.errOutput = os.Stdout
+		l.errOutput = os.Stdout
 	}
 
-	if err := logger.openConnection(); err != nil {
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	if err := l.openConnectionLocked(); err != nil {
 		return nil, err
 	}
 
-	return &logger, nil
+	go l.run()
+	return l, nil
 }
 
-func newEmptyLogger(host, token string, calldepthOffset int) Logger {
-	l := Logger{
-		host:               host,
-		token:              token,
-		calldepthOffset:    calldepthOffset,
-		lastRefreshAt:      time.Now(),
-		writeTimeout:       defaultWriteTimeout,
-		writeLock:          make(chan struct{}, 1),
-		mu:                 make(chan struct{}, 1),
-		_testTimedoutWrite: func() {}, //NOP for prod
-		wg:                 &sync.WaitGroup{},
-		errOutputMutex:     &sync.RWMutex{},
+func WithTestWaitForWrite(wg *sync.WaitGroup) Option {
+	return func(l *Logger) { l._testWaitForWrite = wg }
+}
+
+func WithTestDropped(fn func(DropReason)) Option {
+	return func(l *Logger) { l._testDropped = fn }
+}
+
+func WithDialTimeout(d time.Duration) Option {
+	return func(l *Logger) { l.dialTimeout = d }
+}
+
+func WithWriteTimeout(d time.Duration) Option {
+	return func(l *Logger) { l.writeTimeout = d }
+}
+
+func (l *Logger) Stats() Stats {
+	return Stats{
+		DroppedQueueFull: l.droppedQueueFull.Load(),
+		DroppedClosed:    l.droppedClosed.Load(),
+		DroppedSyncLock:  l.droppedSyncLock.Load(),
+		PanicsRecovered:  l.panicsRecovered.Load(),
 	}
-	unlock(l.writeLock)
-	unlock(l.mu)
-	return l
 }
 
-func (logger *Logger) SetErrorOutput(errOutput io.Writer) {
-	logger.errOutputMutex.Lock()
-	defer logger.errOutputMutex.Unlock()
-	logger.errOutput = errOutput
+func (l *Logger) SetErrorOutput(errOutput io.Writer) {
+	l.errOutputMutex.Lock()
+	defer l.errOutputMutex.Unlock()
+	l.errOutput = errOutput
 }
 
-// Close closes the TCP connection to logentries.com
-func (logger *Logger) Close() error {
-	if logger.conn != nil {
-		return logger.conn.Close()
-	}
+func (l *Logger) SetNumberOfRetries(retries int) {
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	l.numRetries = retries
+}
 
+func (l *Logger) Flags() int {
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	return l.flag
+}
+
+func (l *Logger) SetFlags(flag int) {
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	l.flag = flag
+}
+
+func (l *Logger) Prefix() string {
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	return l.prefix
+}
+
+func (l *Logger) SetPrefix(prefix string) {
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	l.prefix = prefix
+}
+
+// Close signals the logger to shut down and blocks until the async queue
+// is drained and the connection is closed. Idempotent.
+func (l *Logger) Close() error {
+	l.signalShutdown()
+	<-l.exited
 	return nil
 }
 
-// Opens a TCP connection to logentries.com
-func (logger *Logger) openConnection() error {
-	conn, err := tls.Dial("tcp", logger.host, &tls.Config{})
-	if err != nil {
-		return err
+func (l *Logger) signalShutdown() {
+	if l.closed.CompareAndSwap(false, true) {
+		close(l.done)
 	}
-	logger.conn = conn
-	return nil
 }
 
-// It returns if the TCP connection to logentries.com is open
-func (logger *Logger) isOpenConnection() bool {
-	if logger.conn == nil {
-		return false
-	}
-
-	if time.Now().After(logger.lastRefreshAt.Add(15 * time.Minute)) {
-		logger.conn.Close()
-		return false
-	}
-
-	buf := make([]byte, 1)
-
-	logger.conn.SetReadDeadline(time.Now())
-
-	_, err := logger.conn.Read(buf)
-
-	switch err.(type) {
-	case net.Error:
-		if err.(net.Error).Timeout() == true {
-			logger.conn.SetReadDeadline(time.Time{})
-
-			return true
-		}
-	}
-
-	return false
-}
-
-// It ensures that the TCP connection to logentries.com is open.
-// If the connection is closed, a new one is opened.
-func (logger *Logger) ensureOpenConnection() error {
-	if !logger.isOpenConnection() {
-		if err := logger.openConnection(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Fatal is same as Print() but calls to os.Exit(1)
-func (logger *Logger) Fatal(v ...interface{}) {
-	logger.Output(3+logger.calldepthOffset, fmt.Sprint(v...), handleFatalActions)
-}
-
-// Fatalf is same as Printf() but calls to os.Exit(1)
-func (logger *Logger) Fatalf(format string, v ...interface{}) {
-	logger.Output(3+logger.calldepthOffset, fmt.Sprintf(format, v...), handleFatalActions)
-}
-
-// Fatalln is same as Println() but calls to os.Exit(1)
-func (logger *Logger) Fatalln(v ...interface{}) {
-	logger.Output(3+logger.calldepthOffset, fmt.Sprintln(v...), handleFatalActions)
-}
-
-// Flags returns the logger flags
-func (logger *Logger) Flags() int {
-	<-logger.mu
-	defer unlock(logger.mu)
-	return logger.flag
-}
-
-// When we want to use errOutput, make sure it is not being modified in SetErrorOutput
-func (l *Logger) writeToErrOutput(s string) {
-	l.errOutputMutex.RLock()
-	defer l.errOutputMutex.RUnlock()
-	fmt.Fprintf(l.errOutput, s)
-}
-
-// Taken with slight modification from src/log/log.go
-// Output writes the output for a logging event. The string s contains
-// the text to print after the prefix specified by the flags of the
-// Logger. A newline is appended if the last character of s is not
-// already a newline. Calldepth is used to recover the PC and is
-// provided for generality, although at the moment on all pre-defined
-// paths it will be 3 plus a given offset.
-// Output does the actual writing to the TCP connection
-func (l *Logger) Output(calldepth int, s string, doAsync func()) {
-	defer func() {
-		if re := recover(); re != nil {
-			l.writeToErrOutput(fmt.Sprintf("Panicked in logger.output %v\n", re))
-			debug.PrintStack()
-			panic(re)
-		}
-	}()
-	if l.concurrentWrites != nil {
-		select {
-		case <-l.concurrentWrites:
-		default:
-			return
-		}
-	}
-	now := time.Now() // get this early.
-	var file string
-	var line int
-	select {
-	case <-l.mu:
-	case <-time.After(l.writeTimeout):
-		l.writeToErrOutput(fmt.Sprintf("Timedout waiting for logger.mu, wanted to log: %s", s))
-		l._testTimedoutWrite()
+// Output dispatches a log message asynchronously through the channel.
+// Calldepth is provided for runtime.Caller file/line resolution.
+func (l *Logger) Output(calldepth int, s string) {
+	if l.closed.Load() {
+		l.droppedClosed.Add(1)
+		l._testDropped(DropClosed)
 		return
 	}
-	defer unlock(l.mu)
-	if l.flag&(log.Lshortfile|log.Llongfile) != 0 {
-		// Release lock while getting caller info - it's expensive.
-		unlock(l.mu)
+
+	l.cfgMu.Lock()
+	flag, prefix, numRetries := l.flag, l.prefix, l.numRetries
+	l.cfgMu.Unlock()
+
+	var file string
+	var line int
+	if flag&(log.Lshortfile|log.Llongfile) != 0 {
 		var ok bool
 		_, file, line, ok = runtime.Caller(calldepth)
 		if !ok {
 			file = "???"
 			line = 0
 		}
+	}
+
+	s = replaceEmbeddedNewlines(s)
+
+	e := entry{
+		s:          s,
+		file:       file,
+		line:       line,
+		flag:       flag,
+		prefix:     prefix,
+		numRetries: numRetries,
+		now:        time.Now(),
+	}
+
+	if l.closed.Load() {
+		l.droppedClosed.Add(1)
+		l._testDropped(DropClosed)
+		return
+	}
+
+	select {
+	case l.ch <- e:
+	case <-l.done:
+		l.droppedClosed.Add(1)
+		l._testDropped(DropClosed)
+	default:
 		select {
-		case <-l.mu:
-		case <-time.After(l.writeTimeout):
-			l.writeToErrOutput(fmt.Sprintf("Timedout waiting for logger.mu after getting caller info, wanted to log: %s", s))
-			l._testTimedoutWrite()
+		case <-l.done:
+			l.droppedClosed.Add(1)
+			l._testDropped(DropClosed)
+		default:
+			l.droppedQueueFull.Add(1)
+			l._testDropped(DropQueueFull)
+		}
+	}
+}
+
+func (l *Logger) Print(v ...interface{}) {
+	l.Output(3+l.calldepthOffset, fmt.Sprint(v...))
+}
+
+func (l *Logger) Printf(format string, v ...interface{}) {
+	l.Output(3+l.calldepthOffset, fmt.Sprintf(format, v...))
+}
+
+func (l *Logger) Println(v ...interface{}) {
+	l.Output(3+l.calldepthOffset, fmt.Sprintln(v...))
+}
+
+// Write implements io.Writer. It prepends the access token and appends a
+// trailing newline. Write is synchronous and decoupled from the async Print
+// queue — it acquires connMu directly.
+func (l *Logger) Write(p []byte) (int, error) {
+	if l.closed.Load() {
+		return 0, ErrLoggerClosed
+	}
+
+	l.cfgMu.Lock()
+	numRetries := l.numRetries
+	l.cfgMu.Unlock()
+
+	raw := make([]byte, 0, len(l.token)+1+len(p)+1)
+	raw = append(raw, (l.token + " ")...)
+	raw = append(raw, p...)
+	if len(raw) == 0 || raw[len(raw)-1] != '\n' {
+		raw = append(raw, '\n')
+	}
+
+	l.connMu.Lock()
+	defer l.connMu.Unlock()
+
+	if l.closed.Load() {
+		return 0, ErrLoggerClosed
+	}
+	if err := l.ensureOpenConnectionLocked(); err != nil {
+		return 0, err
+	}
+	if err := l.writeRawBytesLocked(raw, numRetries); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// Flush waits for all queued async Print entries to be processed.
+// Returns ErrLoggerClosed if the logger is closed during the wait.
+func (l *Logger) Flush() error {
+	if l.closed.Load() {
+		return ErrLoggerClosed
+	}
+	ack := make(chan error, 1)
+	select {
+	case l.ch <- entry{flush: true, ack: ack}:
+	case <-l.done:
+		return ErrLoggerClosed
+	}
+	select {
+	case err := <-ack:
+		return err
+	case <-l.done:
+		return ErrLoggerClosed
+	}
+}
+
+func (l *Logger) Fatal(v ...interface{}) {
+	s := fmt.Sprint(v...)
+	l.fatalCommon(s, 3+l.calldepthOffset)
+}
+
+func (l *Logger) Fatalf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	l.fatalCommon(s, 3+l.calldepthOffset)
+}
+
+func (l *Logger) Fatalln(v ...interface{}) {
+	s := fmt.Sprintln(v...)
+	l.fatalCommon(s, 3+l.calldepthOffset)
+}
+
+func (l *Logger) fatalCommon(s string, calldepth int) {
+	formatted, file, line, flag, prefix := l.formatMessage(s, calldepth+1)
+
+	l.cfgMu.Lock()
+	numRetries := l.numRetries
+	l.cfgMu.Unlock()
+
+	acquired := l.tryAcquireConnMu(fatalLockWait)
+	if !acquired {
+		l.droppedSyncLock.Add(1)
+		l._testDropped(DropSyncLock)
+		l.writeToErrOutput("Fatal could not acquire conn lock; exiting without flush\n")
+		os.Exit(1)
+	}
+	defer l.connMu.Unlock()
+
+	if !l.closed.Load() {
+		_ = l.writeFormattedMessageLocked(formatted, file, time.Now(), line, flag, prefix, numRetries)
+	}
+	os.Exit(1)
+}
+
+func (l *Logger) Panic(v ...interface{}) {
+	s := fmt.Sprint(v...)
+	l.panicCommon(s, 3+l.calldepthOffset)
+}
+
+func (l *Logger) Panicf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	l.panicCommon(s, 3+l.calldepthOffset)
+}
+
+func (l *Logger) Panicln(v ...interface{}) {
+	s := fmt.Sprintln(v...)
+	l.panicCommon(s, 3+l.calldepthOffset)
+}
+
+func (l *Logger) panicCommon(s string, calldepth int) {
+	formatted, file, line, flag, prefix := l.formatMessage(s, calldepth+1)
+
+	l.cfgMu.Lock()
+	numRetries := l.numRetries
+	l.cfgMu.Unlock()
+
+	acquired := l.tryAcquireConnMu(fatalLockWait)
+	if !acquired {
+		l.droppedSyncLock.Add(1)
+		l._testDropped(DropSyncLock)
+		panic(s)
+	}
+
+	if !l.closed.Load() {
+		_ = l.writeFormattedMessageLocked(formatted, file, time.Now(), line, flag, prefix, numRetries)
+	}
+	l.connMu.Unlock()
+	panic(s)
+}
+
+// --- Consumer goroutine ---
+
+func (l *Logger) run() {
+	defer close(l.exited)
+	panicsSinceLastSuccess := 0
+
+	for {
+		exited := func() bool {
+			defer func() {
+				if r := recover(); r != nil {
+					l.panicsRecovered.Add(1)
+					panicsSinceLastSuccess++
+					l.writeToErrOutput(fmt.Sprintf(
+						"consumer panic recovered (%d/%d): %v\n",
+						panicsSinceLastSuccess, maxConsecutivePanics, r))
+				}
+			}()
+			for {
+				select {
+				case e := <-l.ch:
+					l.processAsync(e, &panicsSinceLastSuccess)
+				case <-l.done:
+					l.drain()
+					l.closeConnLocked()
+					return true
+				}
+			}
+		}()
+
+		if exited {
+			return
+		}
+
+		if panicsSinceLastSuccess >= maxConsecutivePanics {
+			l.writeToErrOutput("consumer hit panic limit; shutting down logger\n")
+			l.signalShutdown()
+			l.drain()
+			l.closeConnLocked()
 			return
 		}
 	}
-
-	// Replace all but the trailing newline with `\u2028`
-	count := strings.Count(s, lineSep)
-	s = strings.Replace(s, lineSep, "\u2028", count-1)
-
-	l.wg.Add(1)
-	go func() {
-		defer l.wg.Done()
-		l.writeToLogEntries(s, file, now, line)
-		doAsync()
-		if l.concurrentWrites != nil {
-			l.concurrentWrites <- struct{}{}
-		}
-	}()
 }
 
-func (l *Logger) Flush() {
-	defer func() {
-		if re := recover(); re != nil {
-			//Protect against misused waitgroups
-			//Usually won't be an issue if the Flush is not waiting a long time
-			log.Println("Recovered while flushing logs")
-		}
-	}()
-	l.wg.Wait()
-}
-
-// Panic is same as Print() but calls to panic
-func (logger *Logger) Panic(v ...interface{}) {
-	s := fmt.Sprint(v...)
-	logger.Output(3+logger.calldepthOffset, s, handlePanicActions(s))
-}
-
-// Panicf is same as Printf() but calls to panic
-func (logger *Logger) Panicf(format string, v ...interface{}) {
-	s := fmt.Sprintf(format, v...)
-	logger.Output(3+logger.calldepthOffset, s, handlePanicActions(s))
-}
-
-// Panicln is same as Println() but calls to panic
-func (logger *Logger) Panicln(v ...interface{}) {
-	s := fmt.Sprintln(v...)
-	logger.Output(3+logger.calldepthOffset, s, handlePanicActions(s))
-}
-
-// Prefix returns the logger prefix
-func (logger *Logger) Prefix() string {
-	<-logger.mu
-	defer unlock(logger.mu)
-	return logger.prefix
-}
-
-// Print logs a message
-func (logger *Logger) Print(v ...interface{}) {
-	logger.Output(3+logger.calldepthOffset, fmt.Sprint(v...), handlePrintActions)
-}
-
-// Printf logs a formatted message
-func (logger *Logger) Printf(format string, v ...interface{}) {
-	logger.Output(3+logger.calldepthOffset, fmt.Sprintf(format, v...), handlePrintActions)
-}
-
-// Println logs a message with a linebreak
-func (logger *Logger) Println(v ...interface{}) {
-	logger.Output(3+logger.calldepthOffset, fmt.Sprintln(v...), handlePrintActions)
-}
-
-// SetFlags sets the logger flags
-func (logger *Logger) SetFlags(flag int) {
-	<-logger.mu
-	defer unlock(logger.mu)
-	logger.flag = flag
-}
-
-func (logger *Logger) SetNumberOfRetries(retries int) {
-	logger.numRetries = retries
-}
-
-// SetPrefix sets the logger prefix
-func (logger *Logger) SetPrefix(prefix string) {
-	<-logger.mu
-	defer unlock(logger.mu)
-	logger.prefix = prefix
-}
-
-// Write writes a bytes array to the Logentries TCP connection,
-// it adds the access token and prefix and also replaces
-// line breaks with the unicode \u2028 character
-func (logger *Logger) Write(p []byte) (n int, err error) {
-	if err := logger.ensureOpenConnection(); err != nil {
-		return 0, err
+func (l *Logger) processAsync(e entry, panicsSinceLastSuccess *int) {
+	if e.flush {
+		e.ack <- nil
+		return
 	}
 
-	return logger.conn.Write(p)
+	l.connMu.Lock()
+	defer l.connMu.Unlock()
+
+	if err := l.writeFormattedMessageLocked(e.s, e.file, e.now, e.line, e.flag, e.prefix, e.numRetries); err != nil {
+		l.writeToErrOutput(fmt.Sprintf("le_go: write error: %s; payload len: %d\n", err, len(e.s)))
+		return
+	}
+
+	*panicsSinceLastSuccess = 0
 }
 
-// Taken wholesale from src/log/log.go
-// formatHeader writes log header to buf in following order:
-//   - l.prefix (if it's not blank),
-//   - date and/or time (if corresponding flags are provided),
-//   - file and line number (if corresponding flags are provided).
-func (l *Logger) formatHeader(buf *[]byte, t time.Time, file string, line int) {
-	*buf = append(*buf, l.prefix...)
-	if l.flag&(log.Ldate|log.Ltime|log.Lmicroseconds) != 0 {
-		if l.flag&log.LUTC != 0 {
+func (l *Logger) drain() {
+	for {
+		select {
+		case e := <-l.ch:
+			if e.flush {
+				e.ack <- nil
+				continue
+			}
+			l.connMu.Lock()
+			if l.conn != nil {
+				_ = l.writeFormattedMessageLocked(e.s, e.file, e.now, e.line, e.flag, e.prefix, e.numRetries)
+			}
+			l.connMu.Unlock()
+		default:
+			return
+		}
+	}
+}
+
+func (l *Logger) closeConnLocked() {
+	l.connMu.Lock()
+	defer l.connMu.Unlock()
+	if l.conn != nil {
+		_ = l.conn.Close()
+		l.conn = nil
+	}
+}
+
+func replaceEmbeddedNewlines(s string) string {
+	s = strings.TrimRight(s, lineSep)
+	return strings.ReplaceAll(s, lineSep, "\u2028")
+}
+
+// --- Formatting & writing ---
+
+// formatMessage builds a fully-formatted log message (token + header + s + \n)
+// for the Fatal/Panic direct path. Called BEFORE acquiring connMu.
+// For messages longer than maxLogLength, this returns the full payload and
+// writeFormattedBytesLocked handles chunking.
+func (l *Logger) formatMessage(s string, calldepth int) (formatted string, file string, line int, flag int, prefix string) {
+	l.cfgMu.Lock()
+	flag, prefix = l.flag, l.prefix
+	l.cfgMu.Unlock()
+
+	if flag&(log.Lshortfile|log.Llongfile) != 0 {
+		var ok bool
+		_, file, line, ok = runtime.Caller(calldepth)
+		if !ok {
+			file = "???"
+			line = 0
+		}
+	}
+
+	formatted = replaceEmbeddedNewlines(s)
+	return
+}
+
+// writeFormattedMessageLocked writes a log message, chunking at maxLogLength.
+// Each chunk is individually prefixed with token + header and newline-terminated.
+// Caller must hold connMu.
+func (l *Logger) writeFormattedMessageLocked(s, file string, now time.Time, line, flag int, prefix string, numRetries int) error {
+	if err := l.ensureOpenConnectionLocked(); err != nil {
+		return err
+	}
+
+	i := 0
+	for {
+		end := i + maxLogLength - 2
+		if end > len(s) {
+			end = len(s)
+		}
+
+		var buf []byte
+		buf = append(buf, (l.token + " ")...)
+		formatHeader(&buf, now, file, line, flag, prefix)
+		buf = append(buf, s[i:end]...)
+		buf = append(buf, '\n')
+
+		if err := l.writeRawBytesLocked(buf, numRetries); err != nil {
+			return err
+		}
+
+		i = end
+		if i >= len(s) {
+			break
+		}
+	}
+	return nil
+}
+
+func formatHeader(buf *[]byte, t time.Time, file string, line int, flag int, prefix string) {
+	*buf = append(*buf, prefix...)
+	if flag&(log.Ldate|log.Ltime|log.Lmicroseconds) != 0 {
+		if flag&log.LUTC != 0 {
 			t = t.UTC()
 		}
-		if l.flag&log.Ldate != 0 {
+		if flag&log.Ldate != 0 {
 			year, month, day := t.Date()
 			itoa(buf, year, 4)
 			*buf = append(*buf, '/')
@@ -354,22 +614,22 @@ func (l *Logger) formatHeader(buf *[]byte, t time.Time, file string, line int) {
 			itoa(buf, day, 2)
 			*buf = append(*buf, ' ')
 		}
-		if l.flag&(log.Ltime|log.Lmicroseconds) != 0 {
+		if flag&(log.Ltime|log.Lmicroseconds) != 0 {
 			hour, min, sec := t.Clock()
 			itoa(buf, hour, 2)
 			*buf = append(*buf, ':')
 			itoa(buf, min, 2)
 			*buf = append(*buf, ':')
 			itoa(buf, sec, 2)
-			if l.flag&log.Lmicroseconds != 0 {
+			if flag&log.Lmicroseconds != 0 {
 				*buf = append(*buf, '.')
 				itoa(buf, t.Nanosecond()/1e3, 6)
 			}
 			*buf = append(*buf, ' ')
 		}
 	}
-	if l.flag&(log.Lshortfile|log.Llongfile) != 0 {
-		if l.flag&log.Lshortfile != 0 {
+	if flag&(log.Lshortfile|log.Llongfile) != 0 {
+		if flag&log.Lshortfile != 0 {
 			short := file
 			for i := len(file) - 1; i > 0; i-- {
 				if file[i] == '/' {
@@ -386,10 +646,7 @@ func (l *Logger) formatHeader(buf *[]byte, t time.Time, file string, line int) {
 	}
 }
 
-// Taken wholesale from src/log/log.go
-// Cheap integer to fixed-width decimal ASCII. Give a negative width to avoid zero-padding.
 func itoa(buf *[]byte, i int, wid int) {
-	// Assemble decimal in reverse order.
 	var b [20]byte
 	bp := len(b) - 1
 	for i >= 10 || wid > 1 {
@@ -399,81 +656,126 @@ func itoa(buf *[]byte, i int, wid int) {
 		bp--
 		i = q
 	}
-	// i < 10
 	b[bp] = byte('0' + i)
 	*buf = append(*buf, b[bp:]...)
 }
 
-func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
-	select {
-	case <-l.writeLock:
-	case <-time.After(l.writeTimeout):
-		//Bail out here
-		l.writeToErrOutput(fmt.Sprintf("%s: Timedout waiting for logging writelock: wanted to log: %s", time.Now().UTC(), s))
-		l._testTimedoutWrite()
-		return
+// --- Connection management (caller must hold connMu) ---
+
+func (l *Logger) openConnectionLocked() error {
+	if l.conn != nil {
+		_ = l.conn.Close()
 	}
 
-	defer unlock(l.writeLock)
+	dialer := &net.Dialer{Timeout: l.dialTimeout}
+	tlsCfg := &tls.Config{}
+	if l.tlsConfig != nil {
+		tlsCfg = l.tlsConfig
+	}
 
-	var i, n int
-	var err error
+	conn, err := tls.DialWithDialer(dialer, "tcp", l.host, tlsCfg)
+	if err != nil {
+		l.conn = nil
+		return err
+	}
 
-	for i = 0; i < len(s); i = i + n {
-		end := i + maxLogLength - 2
-		if end > len(s) {
-			end = len(s)
-		}
-		l.buf = l.buf[:0]
-		l.buf = append(l.buf, (l.token + " ")...)
-		l.formatHeader(&l.buf, now, file, line)
-		l.buf = append(l.buf, s[i:end]...)
-		if len(s) == 0 || s[len(s)-1] != '\n' {
-			l.buf = append(l.buf, '\n')
-		}
-		err = l.conn.SetWriteDeadline(time.Now().Add(l.writeTimeout))
-		if err != nil {
-			log.Printf("le_go: Error setting write deadline: %s", err.Error())
-			log.Printf("Wanted to log: %s", s)
-			return
+	if tc, ok := conn.NetConn().(*net.TCPConn); ok {
+		_ = tc.SetKeepAlive(true)
+		_ = tc.SetKeepAlivePeriod(30 * time.Second)
+	}
+
+	l.conn = conn
+	l.lastRefreshAt = time.Now()
+	return nil
+}
+
+func (l *Logger) ensureOpenConnectionLocked() error {
+	if l.conn == nil || time.Since(l.lastRefreshAt) > 15*time.Minute {
+		return l.openConnectionLocked()
+	}
+	return nil
+}
+
+// writeRawBytesLocked writes data to the TCP connection with retries.
+// Caller must hold connMu. May temporarily release connMu during retry backoff
+// when no bytes have been sent yet (to allow Fatal/Panic TryLock to succeed
+// during the sleep window).
+func (l *Logger) writeRawBytesLocked(data []byte, numRetries int) error {
+	var bytesSent int
+	var lastErr error
+
+	for attempt := 0; attempt <= numRetries; attempt++ {
+		if attempt > 0 {
+			if bytesSent == 0 {
+				l.connMu.Unlock()
+				time.Sleep(retryBackoff)
+				l.connMu.Lock()
+				if l.closed.Load() {
+					return ErrLoggerClosed
+				}
+				if err := l.ensureOpenConnectionLocked(); err != nil {
+					lastErr = err
+					continue
+				}
+			} else {
+				time.Sleep(retryBackoff)
+			}
 		}
 
-		numAttempts := 1 + l.numRetries
-		for i := 0; i < numAttempts; i++ {
-			n, err = l.Write(l.buf)
-			if err != nil {
-				log.Printf("Error in write call: %s", err.Error())
-				log.Printf("Wanted to log: %s", s)
-				<-time.After(100 * time.Millisecond)
+		if l.conn == nil {
+			if err := l.ensureOpenConnectionLocked(); err != nil {
+				lastErr = err
 				continue
 			}
-
-			if l._testWaitForWrite != nil {
-				l._testWaitForWrite.Done()
-			}
-			break
 		}
 
+		if err := l.conn.SetWriteDeadline(time.Now().Add(l.writeTimeout)); err != nil {
+			lastErr = err
+			l.writeToErrOutput(fmt.Sprintf("le_go: SetWriteDeadline error: %s\n", err))
+			continue
+		}
+
+		n, err := l.conn.Write(data)
 		if err != nil {
-			return
+			lastErr = err
+			l.writeToErrOutput(fmt.Sprintf("le_go: write error: %s\n", err))
+			l.conn.Close()
+			l.conn = nil
+			continue
 		}
+
+		bytesSent += n
+		if l._testWaitForWrite != nil {
+			l._testWaitForWrite.Done()
+		}
+		return nil
+	}
+	return lastErr
+}
+
+func (l *Logger) tryAcquireConnMu(budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for {
+		if l.connMu.TryLock() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
-func handleFatalActions() {
-	os.Exit(1)
+func (l *Logger) writeToErrOutput(s string) {
+	l.errOutputMutex.Lock()
+	defer l.errOutputMutex.Unlock()
+	fmt.Fprint(l.errOutput, s)
 }
 
-func handlePanicActions(s string) func() {
-	return func() {
-		panic(s)
-	}
-}
-
-func handlePrintActions() {
-	return
-}
-
-func unlock(c chan struct{}) {
-	c <- struct{}{}
+// withConnLocked calls fn with the current connection while holding connMu.
+// Intended for test use only.
+func (l *Logger) withConnLocked(fn func(net.Conn)) {
+	l.connMu.Lock()
+	defer l.connMu.Unlock()
+	fn(l.conn)
 }

--- a/le_test.go
+++ b/le_test.go
@@ -1,410 +1,1386 @@
 package le_go
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
 
-func TestConnectOpensConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+// =============================================================================
+// Connection Management
+// =============================================================================
 
+func TestConnectOpensConnection(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	if le.conn == nil {
-		t.Fail()
-	}
-
-	if le.isOpenConnection() == false {
-		t.Fail()
-	}
+	le.withConnLocked(func(c net.Conn) {
+		if c == nil {
+			t.Fatal("expected connection to be open")
+		}
+	})
 }
 
 func TestConnectSetsToken(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	if le.token != "myToken" {
-		t.Fail()
+	if le.token != "test-token" {
+		t.Fatalf("expected token 'test-token', got %q", le.token)
 	}
 }
 
 func TestCloseClosesConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
+	le := connectToFakeServer(t, server, 0, nil)
 	le.Close()
 
-	if le.isOpenConnection() == true {
-		t.Fail()
+	le.withConnLocked(func(c net.Conn) {
+		if c != nil {
+			t.Fatal("expected le.conn to be nil after Close")
+		}
+	})
+}
+
+func TestConnectFailsOnBadHost(t *testing.T) {
+	_, err := Connect("127.0.0.1:1", "token", 0, io.Discard, 0, WithDialTimeout(1*time.Second))
+	if err == nil {
+		t.Fatal("expected Connect to fail on bad host")
 	}
 }
 
-func TestOpenConnectionOpensConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer le.Close()
-
-	le.openConnection()
-
-	if le.isOpenConnection() == false {
-		t.Fail()
-	}
-}
-
-func TestEnsureOpenConnectionDoesNothingOnOpenConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer le.Close()
-	old := &le.conn
-
-	le.openConnection()
-
-	if old != &le.conn {
-		t.Fail()
-	}
-}
-
-func TestEnsureOpenConnectionCreatesNewConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer le.Close()
-
-	le.openConnection()
-
-	if le.isOpenConnection() == false {
-		t.Fail()
-	}
-}
+// =============================================================================
+// Configuration
+// =============================================================================
 
 func TestFlagsReturnsFlag(t *testing.T) {
-	le := newEmptyLogger("", "", 0)
-	le.flag = 2
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+	le.SetFlags(2)
 
 	if le.Flags() != 2 {
-		t.Fail()
+		t.Fatalf("expected flag 2, got %d", le.Flags())
 	}
 }
 
 func TestSetFlagsSetsFlag(t *testing.T) {
-	le := newEmptyLogger("", "", 0)
-	le.flag = 2
-
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
 	le.SetFlags(1)
 
-	if le.flag != 1 {
-		t.Fail()
+	if le.Flags() != 1 {
+		t.Fatalf("expected flag 1, got %d", le.Flags())
 	}
 }
 
 func TestPrefixReturnsPrefix(t *testing.T) {
-	le := newEmptyLogger("", "", 0)
-	le.prefix = "myPrefix"
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+	le.SetPrefix("myPrefix")
 
 	if le.Prefix() != "myPrefix" {
-		t.Fail()
+		t.Fatalf("expected prefix 'myPrefix', got %q", le.Prefix())
 	}
 }
 
 func TestSetPrefixSetsPrefix(t *testing.T) {
-	le := newEmptyLogger("", "", 0)
-	le.prefix = "myPrefix"
-
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
 	le.SetPrefix("myNewPrefix")
 
-	if le.prefix != "myNewPrefix" {
-		t.Fail()
+	if le.Prefix() != "myNewPrefix" {
+		t.Fatalf("expected prefix 'myNewPrefix', got %q", le.Prefix())
 	}
 }
 
-func TestLoggerImplementsWriterInterface(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+// =============================================================================
+// Core Logging
+// =============================================================================
 
+func TestPrintSendsToServer(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	// the test will fail to compile if Logger doesn't implement io.Writer
-	func(w io.Writer) {}(le)
+	le.Print("hello")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "test-token ") {
+		t.Fatalf("expected line to start with token, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "hello") {
+		t.Fatalf("expected line to contain 'hello', got %q", lines[0])
+	}
 }
 
-func TestReplaceNewline(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
+func TestPrintfFormatsCorrectly(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.Printf("count: %d", 42)
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "count: 42") {
+		t.Fatalf("expected formatted message, got %q", lines[0])
 	}
+}
 
-	le._testWaitForWrite = &sync.WaitGroup{}
-	le._testWaitForWrite.Add(1)
+func TestPrintlnAppendsNewline(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.Println("hello")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "hello") {
+		t.Fatalf("expected message 'hello', got %q", lines[0])
+	}
+}
+
+func TestPrintlnSendsToServer(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.Println("hello println")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "hello println") {
+		t.Fatalf("expected 'hello println', got %q", lines[0])
+	}
+}
+
+func TestEmptyMessageHandling(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.Print("")
+	le.Flush()
+}
+
+// =============================================================================
+// Newline Replacement
+// =============================================================================
+
+func TestReplaceNewline(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
 	le.Println("1\n2\n3")
+	le.Flush()
 
-	le._testWaitForWrite.Wait()
-
-	if strings.Count(string(le.buf), "\u2028") != 2 {
-		t.Fail()
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if strings.Count(lines[0], "\u2028") < 2 {
+		t.Fatalf("expected at least 2 \\u2028 replacements, got %q", lines[0])
 	}
 }
 
-func TestAddNewline(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestNewlineReplacementEmbeddedOnly(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-	le._testWaitForWrite = &sync.WaitGroup{}
-	le._testWaitForWrite.Add(1)
-
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	le.Print("123")
+	le.Print("hello\nworld")
+	le.Flush()
 
-	le._testWaitForWrite.Wait()
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) > 1 {
+		t.Fatalf("expected 1 line (embedded \\n replaced), got %d lines", len(lines))
+	}
+	if len(lines) == 1 && !strings.Contains(lines[0], "hello\u2028world") {
+		t.Fatalf("expected 'hello\\u2028world' in line, got %q", lines[0])
+	}
+}
 
-	if !strings.HasSuffix(string(le.buf), "\n") {
-		t.Fail()
+func TestAddNewlineWhenMissing(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.Print("hello")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) < 1 {
+		t.Fatal("expected at least 1 line")
+	}
+}
+
+// =============================================================================
+// io.Writer Interface
+// =============================================================================
+
+func TestLoggerImplementsWriterInterface(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	func(w io.Writer) {}(le)
+}
+
+func TestWritePrependsToken(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	n, err := le.Write([]byte("hello via Write\n"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected n > 0")
 	}
 
-	le._testWaitForWrite.Add(1)
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.HasPrefix(lines[0], "test-token ") {
+		t.Fatalf("expected line to start with 'test-token ', got %q", lines[0])
+	}
+}
 
-	le.Printf("%s", "123")
+func TestWriteWithFprintln(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-	le._testWaitForWrite.Wait()
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
 
-	if !strings.HasSuffix(string(le.buf), "\n") {
-		t.Fail()
+	fmt.Fprintln(le, "test via Fprintln")
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.HasPrefix(lines[0], "test-token ") {
+		t.Fatalf("expected line to start with 'test-token ', got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "test via Fprintln") {
+		t.Fatalf("expected line to contain message, got %q", lines[0])
+	}
+}
+
+func TestWriteReturnsFullLength(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	input := []byte("hello world\n")
+	n, err := le.Write(input)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if n != len(input) {
+		t.Fatalf("expected n=%d, got %d", len(input), n)
+	}
+}
+
+func TestWriteReturnsErrLoggerClosed(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	le.Close()
+
+	_, err := le.Write([]byte("after close\n"))
+	if err != ErrLoggerClosed {
+		t.Fatalf("expected ErrLoggerClosed, got %v", err)
+	}
+}
+
+func TestWriteDoesNotBlockBehindPrintQueue(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 5, nil)
+	defer le.Close()
+
+	for i := 0; i < 100; i++ {
+		le.Printf("fill %d", i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		le.Write([]byte("direct write\n"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write blocked behind Print queue")
+	}
+}
+
+func TestWriteErrorReturnsError(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, &discardWriter{})
+	defer le.Close()
+
+	le.connMu.Lock()
+	if le.conn != nil {
+		le.conn.Close()
+	}
+	le.conn = nil
+	le.host = "127.0.0.1:1"
+	le.dialTimeout = 1 * time.Second
+	le.connMu.Unlock()
+
+	_, err := le.Write([]byte("test\n"))
+	if err == nil {
+		t.Fatal("expected Write to return error when connection fails")
+	}
+}
+
+// =============================================================================
+// Flush
+// =============================================================================
+
+func TestFlushWaitsForPendingWrites(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	for i := 0; i < 10; i++ {
+		le.Printf("message %d", i)
+	}
+	le.Flush()
+
+	waitForLines(t, server, 10, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) != 10 {
+		t.Fatalf("expected 10 lines after flush, got %d", len(lines))
+	}
+}
+
+func TestFlushReturnsErrorAfterClose(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	le.Close()
+
+	err := le.Flush()
+	if err != ErrLoggerClosed {
+		t.Fatalf("expected ErrLoggerClosed, got %v", err)
+	}
+}
+
+func TestFlushOnFreshLogger(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	err := le.Flush()
+	if err != nil {
+		t.Fatalf("expected nil error from Flush on fresh logger, got %v", err)
+	}
+}
+
+// =============================================================================
+// Close
+// =============================================================================
+
+func TestCloseWaitsForInFlightWrites(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	server.SetReadDelay(50 * time.Millisecond)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+
+	le.Print("important message")
+	le.Close()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected Close() to wait for in-flight write, but message was lost")
+	}
+}
+
+func TestCloseRejectsNewWrites(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+
+	le.Print("before close")
+	le.Flush()
+	waitForLines(t, server, 1, 5*time.Second)
+
+	linesBefore := len(server.Lines())
+	le.Close()
+
+	le.Print("after close")
+	time.Sleep(200 * time.Millisecond)
+
+	linesAfter := len(server.Lines())
+	if linesAfter > linesBefore {
+		t.Fatal("expected no new lines after Close(), but writes were still accepted")
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+
+	err1 := le.Close()
+	err2 := le.Close()
+	if err1 != nil || err2 != nil {
+		t.Fatalf("expected nil from both Close calls, got %v and %v", err1, err2)
+	}
+}
+
+func TestOutputIgnoredWhenClosed(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 3, nil)
+
+	le.Print("before close")
+	le.Flush()
+	waitForLines(t, server, 1, 5*time.Second)
+
+	le.Close()
+
+	le.Print("after close with small channel")
+	time.Sleep(100 * time.Millisecond)
+
+	if len(server.Lines()) > 1 {
+		t.Fatal("expected no new writes after close")
+	}
+}
+
+// =============================================================================
+// Error Output
+// =============================================================================
+
+func TestWriteFailureLogsToErrOutput(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	var errBuf bytes.Buffer
+	le := connectToFakeServer(t, server, 0, &errBuf)
+
+	le.connMu.Lock()
+	if le.conn != nil {
+		le.conn.Close()
+	}
+	le.conn = nil
+	le.host = "127.0.0.1:1"
+	le.dialTimeout = 1 * time.Second
+	le.connMu.Unlock()
+
+	le.Print("test message")
+	le.Flush()
+	time.Sleep(500 * time.Millisecond)
+
+	errOutput := errBuf.String()
+	if errOutput == "" {
+		t.Fatal("expected error output, got nothing")
+	}
+}
+
+func TestSetErrorOutput(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, &discardWriter{})
+	defer le.Close()
+
+	var buf bytes.Buffer
+	le.SetErrorOutput(&buf)
+	le.writeToErrOutput("test error")
+
+	if buf.String() != "test error" {
+		t.Fatalf("expected 'test error', got %q", buf.String())
+	}
+}
+
+func TestWriteToErrOutputWithPercent(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, &discardWriter{})
+	defer le.Close()
+
+	var errBuf bytes.Buffer
+	le.SetErrorOutput(&errBuf)
+
+	le.writeToErrOutput("100% complete %s %d")
+
+	errOutput := errBuf.String()
+	if strings.Contains(errOutput, "%!") {
+		t.Fatalf("errOutput contains format verb artifacts: %q", errOutput)
+	}
+	if errOutput != "100% complete %s %d" {
+		t.Fatalf("expected exact string, got %q", errOutput)
+	}
+}
+
+func TestSetNumberOfRetries(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetNumberOfRetries(3)
+	le.cfgMu.Lock()
+	retries := le.numRetries
+	le.cfgMu.Unlock()
+	if retries != 3 {
+		t.Fatalf("expected 3 retries, got %d", retries)
+	}
+}
+
+// =============================================================================
+// Connection Refresh / Connection Storm Bug Fix
+// =============================================================================
+
+func TestLastRefreshAtUpdatedOnReconnect(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.connMu.Lock()
+	le.lastRefreshAt = time.Now().Add(-20 * time.Minute)
+	le.connMu.Unlock()
+
+	le.Print("after stale")
+	le.Flush()
+	waitForLines(t, server, 1, 5*time.Second)
+	waitForConnections(t, server, 2, 5*time.Second)
+
+	le.Print("second write")
+	le.Flush()
+	waitForLines(t, server, 2, 5*time.Second)
+
+	if server.ConnectionCount() > 2 {
+		t.Fatalf("expected 2 connections (initial + 1 reconnect), got %d", server.ConnectionCount())
+	}
+}
+
+func TestConnectionRefreshDoesNotReconnectEveryWrite(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.connMu.Lock()
+	le.lastRefreshAt = time.Now().Add(-20 * time.Minute)
+	le.connMu.Unlock()
+
+	for i := 0; i < 5; i++ {
+		le.Printf("msg %d", i)
+		le.Flush()
+	}
+	waitForLines(t, server, 5, 5*time.Second)
+
+	if server.ConnectionCount() > 2 {
+		t.Fatalf("expected 2 connections, got %d", server.ConnectionCount())
+	}
+}
+
+func TestOldConnectionClosedOnReconnect(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	var initialConn net.Conn
+	le.withConnLocked(func(c net.Conn) {
+		initialConn = c
+	})
+
+	le.connMu.Lock()
+	le.lastRefreshAt = time.Now().Add(-20 * time.Minute)
+	le.connMu.Unlock()
+
+	le.Print("trigger reconnect")
+	le.Flush()
+	waitForLines(t, server, 1, 5*time.Second)
+
+	_, err := initialConn.Write([]byte("test"))
+	if err == nil {
+		t.Fatal("expected initial connection to be closed after reconnect")
+	}
+}
+
+// =============================================================================
+// Chunking
+// =============================================================================
+
+func TestChunkingContentCorrectness(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	msgBytes := make([]byte, 140000)
+	for i := range msgBytes {
+		msgBytes[i] = byte('a' + (i % 26))
+	}
+	msg := string(msgBytes)
+
+	le.Print(msg)
+	le.Flush()
+
+	waitForLines(t, server, 2, 10*time.Second)
+	lines := server.Lines()
+
+	var reassembled strings.Builder
+	for _, line := range lines {
+		content := stripTokenAndHeader(line, "test-token")
+		reassembled.WriteString(content)
+	}
+
+	got := reassembled.String()
+	if !strings.Contains(got, msg[:1000]) {
+		t.Fatal("expected reassembled message to contain start of original")
+	}
+	if len(got) < len(msg) {
+		t.Fatalf("expected reassembled length >= %d, got %d (data was lost)", len(msg), len(got))
+	}
+}
+
+func TestChunkingExactBoundary(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	msgBytes := make([]byte, maxLogLength-2)
+	for i := range msgBytes {
+		msgBytes[i] = 'x'
+	}
+	msg := string(msgBytes)
+
+	le.Print(msg)
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line for exact boundary message, got %d", len(lines))
+	}
+
+	content := stripTokenAndHeader(lines[0], "test-token")
+	if len(content) < len(msg) {
+		t.Fatalf("expected content length >= %d, got %d", len(msg), len(content))
 	}
 }
 
 func TestCanSendMoreThan64k(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-	le._testWaitForWrite = &sync.WaitGroup{}
-	le._testWaitForWrite.Add(3) // 3 because we need to write 3 times since it exceeds the limit (64k)
-
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
 	longBytes := make([]byte, 140000)
-	for i := 0; i < 140000; i++ {
+	for i := range longBytes {
 		longBytes[i] = 'a'
 	}
-	longString := string(longBytes)
-	// Fake the connection so we can hear about it
-	fakeConn := fakeConnection{}
-	le.conn = &fakeConn
-	le.Print(longString)
+	le.Print(string(longBytes))
+	le.Flush()
 
-	le._testWaitForWrite.Wait()
-
-	if fakeConn.WriteCalls < 2 {
-		t.Fail()
+	waitForLines(t, server, 2, 10*time.Second)
+	lines := server.Lines()
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines for 140KB message, got %d", len(lines))
 	}
 }
 
-func TestTimeoutWrites(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	timedoutCount := 0
-	le._testTimedoutWrite = func() {
-		timedoutCount++
-	}
+func TestChunkingMultipleChunks(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-	le._testWaitForWrite = &sync.WaitGroup{}
-	le._testWaitForWrite.Add(1)
-
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	b := make([]byte, 1000)
-	for i := 0; i < 1000; i++ {
-		b[i] = 'a'
+	longBytes := make([]byte, 200000)
+	for i := range longBytes {
+		longBytes[i] = byte('A' + (i % 26))
 	}
-	s := string(b)
-	// Fake the connection so we can hear about it
-	fakeConn := fakeConnection{
-		writeDuration: 12 * time.Second,
-	}
-	le.conn = &fakeConn
-	go le.Print(s)
-	go le.Print(s)
+	le.Print(string(longBytes))
+	le.Flush()
 
-	le._testWaitForWrite.Wait()
+	waitForLines(t, server, 3, 10*time.Second)
+	lines := server.Lines()
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 chunks for 200KB message, got %d", len(lines))
+	}
 
-	if fakeConn.SetWriteTimeoutCalls < 1 {
-		t.Fail()
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "test-token ") {
+			t.Fatalf("chunk %d missing token prefix: %q", i, line[:50])
+		}
 	}
-	if timedoutCount < 1 {
-		t.Fail()
+}
+
+func TestEachChunkNewlineTerminated(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	msgBytes := make([]byte, maxLogLength*2+1000)
+	for i := range msgBytes {
+		msgBytes[i] = byte('a' + (i % 26))
 	}
+	msg := string(msgBytes)
+
+	le.Print(msg)
+	le.Flush()
+
+	waitForLines(t, server, 3, 10*time.Second)
+	lines := server.Lines()
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 separate lines (one per chunk), got %d", len(lines))
+	}
+}
+
+// =============================================================================
+// Header Formatting
+// =============================================================================
+
+func TestOutputWithShortfileFlag(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+	le.calldepthOffset = -1
+
+	le.SetFlags(1 << 4) // log.Lshortfile
+	le.Print("with file info")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "le_test.go:") {
+		t.Fatalf("expected filename in output, got %q", lines[0])
+	}
+}
+
+func TestOutputWithLongfileFlag(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+	le.calldepthOffset = -1
+
+	le.SetFlags(1 << 3) // log.Llongfile
+	le.Print("with long file info")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "/le_test.go:") {
+		t.Fatalf("expected full path in output, got %q", lines[0])
+	}
+}
+
+func TestHeaderFormattingWithDateAndTime(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetFlags(1 | 2) // log.Ldate | log.Ltime
+	le.Print("with datetime")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "/") || !strings.Contains(lines[0], ":") {
+		t.Fatalf("expected date/time in output, got %q", lines[0])
+	}
+}
+
+func TestHeaderFormattingWithMicroseconds(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetFlags(2 | 4) // log.Ltime | log.Lmicroseconds
+	le.Print("with microseconds")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], ".") {
+		t.Fatalf("expected microseconds in output, got %q", lines[0])
+	}
+}
+
+func TestHeaderFormattingWithUTC(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetFlags(1 | 2 | 32) // log.Ldate | log.Ltime | log.LUTC
+	le.Print("with utc")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "with utc") {
+		t.Fatalf("expected message in output, got %q", lines[0])
+	}
+}
+
+func TestHeaderFormattingWithShortfileAndDate(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+	le.calldepthOffset = -1
+
+	le.SetFlags(1 | 2 | 16) // log.Ldate | log.Ltime | log.Lshortfile
+	le.Print("full header")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "le_test.go:") {
+		t.Fatalf("expected filename in output, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "/") {
+		t.Fatalf("expected date separator in output, got %q", lines[0])
+	}
+}
+
+func TestHeaderFormattingWithPrefix(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetPrefix("[APP] ")
+	le.Print("prefixed message")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if !strings.Contains(lines[0], "[APP] ") {
+		t.Fatalf("expected prefix '[APP] ' in output, got %q", lines[0])
+	}
+}
+
+// =============================================================================
+// Dial Timeout
+// =============================================================================
+
+func TestDialTimeout(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().String()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := Connect(addr, "token", 0, io.Discard, 0, WithDialTimeout(2*time.Second))
+		done <- err
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Connect hung for >15s — no dial timeout")
+	}
+}
+
+// =============================================================================
+// Retry
+// =============================================================================
+
+func TestWriteRawRetriesOnFailure(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetNumberOfRetries(2)
+
+	le.connMu.Lock()
+	if le.conn != nil {
+		le.conn.Close()
+	}
+	le.conn = nil
+	le.connMu.Unlock()
+
+	le.Print("after reconnect")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected message after retry/reconnect")
+	}
+}
+
+func TestWriteRawRetriesAndReconnects(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	le.SetNumberOfRetries(2)
+
+	le.connMu.Lock()
+	if le.conn != nil {
+		le.conn.Close()
+	}
+	le.conn = nil
+	le.connMu.Unlock()
+
+	le.Print("retry message")
+	le.Flush()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected message after retry+reconnect")
+	}
+}
+
+// =============================================================================
+// Pipeline — Lifecycle & Goroutine Management
+// =============================================================================
+
+func TestPipeline_LifecycleStartupShutdown(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	le.Close()
+
+	select {
+	case <-le.exited:
+	default:
+		t.Fatal("expected exited channel to be closed after Close")
+	}
+}
+
+func TestPipeline_BoundedGoroutines(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 100, nil)
+	defer le.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			le.Printf("msg %d", i)
+		}(i)
+	}
+	wg.Wait()
+	le.Flush()
+}
+
+func TestPipeline_DropCounter(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	server.SetReadDelay(100 * time.Millisecond)
+	le := connectToFakeServer(t, server, 2, nil)
+	defer le.Close()
+
+	for i := 0; i < 100; i++ {
+		le.Printf("message %d", i)
+	}
+	le.Flush()
+
+	stats := le.Stats()
+	if stats.DroppedQueueFull == 0 {
+		t.Fatal("expected some drops due to queue full, got 0")
+	}
+}
+
+func TestPipeline_DropCounterClosed(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	le.Close()
+
+	le.Print("after close")
+	le.Print("after close 2")
+
+	stats := le.Stats()
+	if stats.DroppedClosed == 0 {
+		t.Fatal("expected DroppedClosed > 0, got 0")
+	}
+}
+
+func TestPipeline_FIFOOrdering(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	for i := 0; i < 50; i++ {
+		le.Printf("seq-%03d", i)
+	}
+	le.Flush()
+
+	waitForLines(t, server, 50, 10*time.Second)
+	lines := server.Lines()
+
+	for i := 0; i < len(lines); i++ {
+		expected := fmt.Sprintf("seq-%03d", i)
+		if !strings.Contains(lines[i], expected) {
+			t.Fatalf("FIFO violation at index %d: expected %q, got %q", i, expected, lines[i])
+		}
+	}
+}
+
+func TestPipeline_CloseDuringInFlight(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+
+	for i := 0; i < 20; i++ {
+		le.Printf("inflight-%d", i)
+	}
+	le.Close()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected at least some messages to be drained on Close")
+	}
+}
+
+// =============================================================================
+// Pipeline — Drop via test hook
+// =============================================================================
+
+func TestPipeline_DropHookFires(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	var mu sync.Mutex
+	drops := make(map[DropReason]int)
+
+	server.SetReadDelay(100 * time.Millisecond)
+	le := connectToFakeServer(t, server, 2, nil, WithTestDropped(func(r DropReason) {
+		mu.Lock()
+		drops[r]++
+		mu.Unlock()
+	}))
+	defer le.Close()
+
+	for i := 0; i < 100; i++ {
+		le.Printf("msg %d", i)
+	}
+	le.Flush()
+
+	mu.Lock()
+	queueFull := drops[DropQueueFull]
+	mu.Unlock()
+
+	if queueFull == 0 {
+		t.Fatal("expected DropQueueFull hook to fire, got 0")
+	}
+}
+
+// =============================================================================
+// Concurrency
+// =============================================================================
+
+func TestConcurrentPrintAndFlush(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			le.Printf("message %d", i)
+		}(i)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		le.Flush()
+	}()
+
+	wg.Wait()
+	le.Flush()
 }
 
 func TestLimitedConcurrentWrites(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 3, io.Discard, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	timedoutCount := 0
-	le._testTimedoutWrite = func() {
-		timedoutCount++
-	}
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-	le._testWaitForWrite = &sync.WaitGroup{}
-	le._testWaitForWrite.Add(1)
-
+	le := connectToFakeServer(t, server, 3, nil)
 	defer le.Close()
 
-	b := make([]byte, 1000)
-	for i := 0; i < 1000; i++ {
-		b[i] = 'a'
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			le.Printf("concurrent %d", i)
+		}(i)
 	}
-	s := string(b)
-	// Fake the connection so we can hear about it
-	fakeConn := fakeConnection{
-		writeDuration: 1 * time.Second,
+	wg.Wait()
+	le.Flush()
+
+	lines := server.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected at least some messages to be sent")
 	}
-	le.conn = &fakeConn
-	le.writeTimeout = 500 * time.Millisecond
+	if len(lines) > 50 {
+		t.Fatalf("expected at most 50 messages, got %d", len(lines))
+	}
+}
+
+func TestWriteConcurrentWithPrint(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			le.Printf("print %d", i)
+		}(i)
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			le.Write([]byte(fmt.Sprintf("write %d\n", i)))
+		}(i)
+	}
+
+	wg.Wait()
+	le.Flush()
+
+	waitForLines(t, server, 20, 10*time.Second)
+}
+
+// =============================================================================
+// Backpressure / Drops
+// =============================================================================
+
+func TestDroppedLogsUnderBackpressure(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	server.SetReadDelay(100 * time.Millisecond)
+	le := connectToFakeServer(t, server, 2, nil)
+	defer le.Close()
+
 	for i := 0; i < 100; i++ {
-		go le.Print(s)
+		le.Printf("message %d", i)
 	}
+	le.Flush()
 
-	le._testWaitForWrite.Wait()
-
-	if fakeConn.SetWriteTimeoutCalls < 1 {
-		t.Fatalf("SetWriteTimeoutCalls should be > 1, got %d", fakeConn.SetWriteTimeoutCalls)
-	}
-	if fakeConn.SetWriteTimeoutCalls > 3 {
-		t.Fatalf("SetWriteTimeoutCalls should be 3, got %d", fakeConn.SetWriteTimeoutCalls)
-	}
-	if timedoutCount < 1 {
-		t.Fatalf("timedoutCount should be > 1, got %d", timedoutCount)
-	}
-	//Note only 3 timeouts when we have 100 writes, because we only have 3 concurrent writes
-	if timedoutCount > 3 {
-		t.Fatalf("timedoutCount should be 3, got %d", timedoutCount)
+	lines := server.Lines()
+	if len(lines) > 100 {
+		t.Fatalf("expected at most 100 lines, got %d", len(lines))
 	}
 }
 
-type fakeConnection struct {
-	WriteCalls           int
-	SetWriteTimeoutCalls int
-	writeDuration        time.Duration
-}
+// =============================================================================
+// Stats
+// =============================================================================
 
-func (f *fakeConnection) Write(b []byte) (int, error) {
-	<-time.After(f.writeDuration)
-	f.WriteCalls++
-	return len(b), nil
-}
+func TestStats_AllCounters(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-func (f *fakeConnection) SetWriteDeadline(t time.Time) error {
-	f.SetWriteTimeoutCalls++
-	return nil
-}
+	server.SetReadDelay(100 * time.Millisecond)
+	le := connectToFakeServer(t, server, 2, nil)
 
-func (*fakeConnection) Read(b []byte) (int, error) {
-	return len(b), &fakeError{}
-}
+	for i := 0; i < 50; i++ {
+		le.Printf("fill %d", i)
+	}
+	le.Flush()
 
-func (*fakeConnection) SetReadDeadline(time.Time) error { return nil }
-
-func (*fakeConnection) Close() error                  { return nil }
-func (*fakeConnection) LocalAddr() net.Addr           { return &fakeAddr{} }
-func (*fakeConnection) RemoteAddr() net.Addr          { return &fakeAddr{} }
-func (*fakeConnection) SetDeadline(t time.Time) error { return nil }
-
-type fakeError struct{}
-
-func (*fakeError) Error() string {
-	return "fake network error"
-}
-
-func (*fakeError) Timeout() bool {
-	return true
-}
-
-func (*fakeError) Temporary() bool {
-	return true
-}
-
-type fakeAddr struct{}
-
-func (f *fakeAddr) Network() string { return "" }
-func (f *fakeAddr) String() string  { return "" }
-
-func ExampleLogger() {
-	le, err := Connect("data.logentries.com:443", "XXXX-XXXX-XXXX-XXXX", 0, os.Stderr, 0) // replace with token
-	if err != nil {
-		panic(err)
+	stats := le.Stats()
+	if stats.DroppedQueueFull == 0 {
+		t.Fatal("expected DroppedQueueFull > 0")
 	}
 
+	le.Close()
+
+	le.Print("after close")
+	stats = le.Stats()
+	if stats.DroppedClosed == 0 {
+		t.Fatal("expected DroppedClosed > 0")
+	}
+}
+
+// =============================================================================
+// Panic recovery
+// =============================================================================
+
+func TestPanic_RecoverableByCaller(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
+
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	le.Println("another test message")
+	recovered := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				recovered = true
+				if s, ok := r.(string); !ok || !strings.Contains(s, "test panic") {
+					t.Fatalf("expected panic with 'test panic', got %v", r)
+				}
+			}
+		}()
+		le.Panic("test panic")
+	}()
+
+	if !recovered {
+		t.Fatal("expected Panic to be recoverable in caller")
+	}
 }
 
-func ExampleLogger_write() {
-	le, err := Connect("data.logentries.com:443", "XXXX-XXXX-XXXX-XXXX", 0, os.Stderr, 0) // replace with token
-	if err != nil {
-		panic(err)
-	}
+func TestPanic_MessageWrittenBeforePanic(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
+	le := connectToFakeServer(t, server, 0, nil)
 	defer le.Close()
 
-	fmt.Fprintln(le, "another test message")
+	func() {
+		defer func() { recover() }()
+		le.Panic("panic msg")
+	}()
+
+	waitForLines(t, server, 1, 5*time.Second)
+	lines := server.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected panic message to be written before panic")
+	}
+	if !strings.Contains(lines[0], "panic msg") {
+		t.Fatalf("expected panic message in output, got %q", lines[0])
+	}
 }
 
-// func BenchmarkMakeBuf(b *testing.B) {
-// 	le := Logger{token: "token"}
+// =============================================================================
+// Connect branches
+// =============================================================================
 
-// 	for i := 0; i < b.N; i++ {
-// 		le.makeBuf([]byte("test\nstring\n"))
-// 	}
-// }
+func TestConnectWithNilErrOutput(t *testing.T) {
+	server := newFakeLogentriesServer(t)
+	defer server.Close()
 
-// func BenchmarkMakeBufWithoutNewlineSuffix(b *testing.B) {
-// 	le := Logger{token: "token"}
+	le := connectToFakeServer(t, server, 0, nil)
+	defer le.Close()
 
-// 	for i := 0; i < b.N; i++ {
-// 		le.makeBuf([]byte("test\nstring"))
-// 	}
-// }
-
-// func BenchmarkMakeBufWithPrefix(b *testing.B) {
-// 	le := Logger{token: "token"}
-// 	le.SetPrefix("prefix")
-
-// 	for i := 0; i < b.N; i++ {
-// 		le.makeBuf([]byte("test\nstring\n"))
-// 	}
-// }
+	if le.errOutput == nil {
+		t.Fatal("expected errOutput to be non-nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces spawn-per-call goroutine + channel-as-mutex design with a three-path architecture: async bounded channel for Print-family (single consumer goroutine), direct `connMu` for Write (io.Writer), and TryLock-bounded (500ms) direct path for Fatal/Panic.
- Fixes 18+ bugs from the original audit: unbounded goroutine fan-out, chunk truncation, connection storm (`lastRefreshAt` never updated), async Fatal/Panic, channel-as-mutex anti-pattern, shared `buf` race, missing dial timeout, `Fprintf` format-string bug in errOutput.
- Adds `Stats()` with drop counters (`DroppedQueueFull`, `DroppedClosed`, `DroppedSyncLock`, `PanicsRecovered`), `Flush() error`, `ErrLoggerClosed` sentinel, `Option` pattern on `Connect`, TCP keepalive for half-open detection, consumer panic recovery with circuit breaker, and FIFO ordering guarantee for the Print path.

## Behavior changes (see package godoc for full list)

- `Write` now prepends token and appends newline (was raw passthrough)
- `Fatal`/`Panic` are synchronous in caller goroutine; `Panic` is recoverable via `defer recover()`
- `Close` is idempotent and drains the async queue before returning
- `concurrentWrites` parameter now controls channel buffer capacity (default 4096)
- Half-open TCP detection via OS keepalive instead of per-call read probe

## Test plan

- [x] `go test -race -count=5` passes (65 tests, zero races)
- [x] `go vet` clean
- [ ] Review chunking correctness for large messages (>64KB)
- [ ] Review Fatal/Panic TryLock behavior under connMu contention
- [ ] Review consumer panic recovery + circuit breaker threshold
- [ ] Verify callers of `le_go` are unaffected by API-compatible changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)