### PR TITLE
Fix connection storm: replace forced reconnect with write-failure reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
  - Add retries 
- - Fix connection storm: update lastRefreshAt on reconnect so connections are reused past 15 minutes
+ - Fix connection storm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
  - Add retries 
- - Fix connection storm
+ - Replace 15-minute forced reconnect with TCP keepalive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,4 @@
  - Add `calldepthOffset` param to allow users to change the calldepth that is logged
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
- - Add retries 
  - Replace 15-minute forced reconnect with TCP keepalive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,4 @@
  - Add `calldepthOffset` param to allow users to change the calldepth that is logged
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
- - Add retries 
  - Fix connection storm: replace 15-minute forced reconnect with write-failure reconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
  - Add retries 
+ - Fix connection storm: update lastRefreshAt on reconnect so connections are reused past 15 minutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,5 @@
  - Add `calldepthOffset` param to allow users to change the calldepth that is logged
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
+ - Add retries
  - Fix connection storm: replace 15-minute forced reconnect with write-failure reconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,5 @@
  - Add `calldepthOffset` param to allow users to change the calldepth that is logged
  - Allow error output to be set
  - Ensure that when we are using errorOutput, it is threadsafe
- - Replace 15-minute forced reconnect with TCP keepalive
+ - Add retries 
+ - Fix connection storm: replace 15-minute forced reconnect with write-failure reconnect

--- a/le.go
+++ b/le.go
@@ -114,6 +114,7 @@ func (logger *Logger) openConnection() error {
 		return err
 	}
 	logger.conn = conn
+	logger.lastRefreshAt = time.Now()
 	return nil
 }
 

--- a/le.go
+++ b/le.go
@@ -122,17 +122,11 @@ func (logger *Logger) openConnection() error {
 	return nil
 }
 
-// ensureOpenConnection reconnects if the connection has been nil'd out
-// (e.g. after a write failure or Close).
-//
-// Connection strategy: we don't probe or force-refresh the connection.
-// Instead we follow the same pattern used by Rapid7's official clients
-// (r7insight_node, r7insight_python, r7insight_java): just write, and
-// if it fails, nil the conn and reconnect on the next attempt. None of
-// the official clients use TCP keepalive or periodic reconnects.
-// See: https://github.com/rapid7/r7insight_node
-//      https://github.com/rapid7/r7insight_python
-//      https://github.com/rapid7/r7insight_java
+// ensureOpenConnection reconnects if conn is nil. Matches the
+// write-fail-then-reconnect pattern used by Rapid7's official clients:
+//   https://github.com/rapid7/r7insight_node
+//   https://github.com/rapid7/r7insight_python
+//   https://github.com/rapid7/r7insight_java
 func (logger *Logger) ensureOpenConnection() error {
 	if logger.conn == nil {
 		return logger.openConnection()
@@ -416,10 +410,7 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 		numAttempts := 1 + l.numRetries
 		for i := 0; i < numAttempts; i++ {
 			if err = l.ensureOpenConnection(); err != nil {
-				log.Printf("le_go: Error reconnecting: %s", err.Error())
-				log.Printf("Wanted to log: %s", s)
-				// Always allow at least one reconnect attempt so a
-				// stale connection doesn't silently discard the log.
+				// Ensure at least one retry so a stale conn doesn't drop the log.
 				if numAttempts < 2 {
 					numAttempts = 2
 				}
@@ -441,8 +432,6 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 					l.conn.Close()
 					l.conn = nil
 				}
-				// Always allow at least one reconnect attempt so a
-				// stale connection doesn't silently discard the log.
 				if numAttempts < 2 {
 					numAttempts = 2
 				}

--- a/le.go
+++ b/le.go
@@ -99,59 +99,39 @@ func (logger *Logger) SetErrorOutput(errOutput io.Writer) {
 // Close closes the TCP connection to logentries.com
 func (logger *Logger) Close() error {
 	if logger.conn != nil {
-		return logger.conn.Close()
+		err := logger.conn.Close()
+		logger.conn = nil
+		return err
 	}
 
 	return nil
 }
 
-// Opens a TCP connection to logentries.com
+// openConnection opens a new TLS connection to logentries.com.
 func (logger *Logger) openConnection() error {
 	conn, err := tls.Dial("tcp", logger.host, &tls.Config{})
 	if err != nil {
 		return err
 	}
-	if tc, ok := conn.NetConn().(*net.TCPConn); ok {
-		tc.SetKeepAlive(true)
-		tc.SetKeepAlivePeriod(30 * time.Second)
-	}
 	logger.conn = conn
 	return nil
 }
 
-// It returns if the TCP connection to logentries.com is open
-func (logger *Logger) isOpenConnection() bool {
-	if logger.conn == nil {
-		return false
-	}
-
-	buf := make([]byte, 1)
-
-	logger.conn.SetReadDeadline(time.Now())
-
-	_, err := logger.conn.Read(buf)
-
-	switch err.(type) {
-	case net.Error:
-		if err.(net.Error).Timeout() == true {
-			logger.conn.SetReadDeadline(time.Time{})
-
-			return true
-		}
-	}
-
-	return false
-}
-
-// It ensures that the TCP connection to logentries.com is open.
-// If the connection is closed, a new one is opened.
+// ensureOpenConnection reconnects if the connection has been nil'd out
+// (e.g. after a write failure or Close).
+//
+// Connection strategy: we don't probe or force-refresh the connection.
+// Instead we follow the same pattern used by Rapid7's official clients
+// (r7insight_node, r7insight_python, r7insight_java): just write, and
+// if it fails, nil the conn and reconnect on the next attempt. None of
+// the official clients use TCP keepalive or periodic reconnects.
+// See: https://github.com/rapid7/r7insight_node
+//      https://github.com/rapid7/r7insight_python
+//      https://github.com/rapid7/r7insight_java
 func (logger *Logger) ensureOpenConnection() error {
-	if !logger.isOpenConnection() {
-		if err := logger.openConnection(); err != nil {
-			return err
-		}
+	if logger.conn == nil {
+		return logger.openConnection()
 	}
-
 	return nil
 }
 
@@ -441,6 +421,11 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 			if err != nil {
 				log.Printf("Error in write call: %s", err.Error())
 				log.Printf("Wanted to log: %s", s)
+				// Nil the conn so ensureOpenConnection reconnects on retry.
+				if l.conn != nil {
+					l.conn.Close()
+					l.conn = nil
+				}
 				<-time.After(100 * time.Millisecond)
 				continue
 			}

--- a/le.go
+++ b/le.go
@@ -42,6 +42,7 @@ type Logger struct {
 	errOutput          io.Writer
 	errOutputMutex     *sync.RWMutex
 	numRetries         int
+	tlsConfig          *tls.Config
 }
 
 const lineSep = "\n"
@@ -109,7 +110,11 @@ func (logger *Logger) Close() error {
 
 // openConnection opens a new TLS connection to logentries.com.
 func (logger *Logger) openConnection() error {
-	conn, err := tls.Dial("tcp", logger.host, &tls.Config{})
+	cfg := logger.tlsConfig
+	if cfg == nil {
+		cfg = &tls.Config{}
+	}
+	conn, err := tls.Dial("tcp", logger.host, cfg)
 	if err != nil {
 		return err
 	}
@@ -408,16 +413,26 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 		if len(s) == 0 || s[len(s)-1] != '\n' {
 			l.buf = append(l.buf, '\n')
 		}
-		err = l.conn.SetWriteDeadline(time.Now().Add(l.writeTimeout))
-		if err != nil {
-			log.Printf("le_go: Error setting write deadline: %s", err.Error())
-			log.Printf("Wanted to log: %s", s)
-			return
-		}
-
 		numAttempts := 1 + l.numRetries
 		for i := 0; i < numAttempts; i++ {
-			n, err = l.Write(l.buf)
+			if err = l.ensureOpenConnection(); err != nil {
+				log.Printf("le_go: Error reconnecting: %s", err.Error())
+				log.Printf("Wanted to log: %s", s)
+				// Always allow at least one reconnect attempt so a
+				// stale connection doesn't silently discard the log.
+				if numAttempts < 2 {
+					numAttempts = 2
+				}
+				<-time.After(100 * time.Millisecond)
+				continue
+			}
+			err = l.conn.SetWriteDeadline(time.Now().Add(l.writeTimeout))
+			if err != nil {
+				log.Printf("le_go: Error setting write deadline: %s", err.Error())
+				log.Printf("Wanted to log: %s", s)
+				return
+			}
+			n, err = l.conn.Write(l.buf)
 			if err != nil {
 				log.Printf("Error in write call: %s", err.Error())
 				log.Printf("Wanted to log: %s", s)
@@ -425,6 +440,11 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 				if l.conn != nil {
 					l.conn.Close()
 					l.conn = nil
+				}
+				// Always allow at least one reconnect attempt so a
+				// stale connection doesn't silently discard the log.
+				if numAttempts < 2 {
+					numAttempts = 2
 				}
 				<-time.After(100 * time.Millisecond)
 				continue

--- a/le.go
+++ b/le.go
@@ -35,7 +35,6 @@ type Logger struct {
 	host               string
 	token              string
 	buf                []byte
-	lastRefreshAt      time.Time
 	writeTimeout       time.Duration
 	_testWaitForWrite  *sync.WaitGroup
 	_testTimedoutWrite func()
@@ -79,7 +78,6 @@ func newEmptyLogger(host, token string, calldepthOffset int) Logger {
 		host:               host,
 		token:              token,
 		calldepthOffset:    calldepthOffset,
-		lastRefreshAt:      time.Now(),
 		writeTimeout:       defaultWriteTimeout,
 		writeLock:          make(chan struct{}, 1),
 		mu:                 make(chan struct{}, 1),
@@ -113,19 +111,17 @@ func (logger *Logger) openConnection() error {
 	if err != nil {
 		return err
 	}
+	if tc, ok := conn.NetConn().(*net.TCPConn); ok {
+		tc.SetKeepAlive(true)
+		tc.SetKeepAlivePeriod(30 * time.Second)
+	}
 	logger.conn = conn
-	logger.lastRefreshAt = time.Now()
 	return nil
 }
 
 // It returns if the TCP connection to logentries.com is open
 func (logger *Logger) isOpenConnection() bool {
 	if logger.conn == nil {
-		return false
-	}
-
-	if time.Now().After(logger.lastRefreshAt.Add(15 * time.Minute)) {
-		logger.conn.Close()
 		return false
 	}
 

--- a/le_test.go
+++ b/le_test.go
@@ -23,7 +23,7 @@ func TestConnectOpensConnection(t *testing.T) {
 		t.Fail()
 	}
 
-	if le.isOpenConnection() == false {
+	if le.conn == nil {
 		t.Fail()
 	}
 }
@@ -49,7 +49,7 @@ func TestCloseClosesConnection(t *testing.T) {
 
 	le.Close()
 
-	if le.isOpenConnection() == true {
+	if le.conn != nil {
 		t.Fail()
 	}
 }
@@ -64,7 +64,7 @@ func TestOpenConnectionOpensConnection(t *testing.T) {
 
 	le.openConnection()
 
-	if le.isOpenConnection() == false {
+	if le.conn == nil {
 		t.Fail()
 	}
 }
@@ -95,7 +95,7 @@ func TestEnsureOpenConnectionCreatesNewConnection(t *testing.T) {
 
 	le.openConnection()
 
-	if le.isOpenConnection() == false {
+	if le.conn == nil {
 		t.Fail()
 	}
 }

--- a/le_test.go
+++ b/le_test.go
@@ -1,8 +1,15 @@
 package le_go
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"os"
 	"strings"
@@ -11,92 +18,181 @@ import (
 	"time"
 )
 
-func TestConnectOpensConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
+// newTestLogger creates a Logger with a fakeConnection, suitable for tests
+// that don't need real network connectivity.
+func newTestLogger(token string, concurrentWrites int) *Logger {
+	l := newEmptyLogger("", token, 0)
+	l.conn = &fakeConnection{}
+	l.errOutput = io.Discard
+	if concurrentWrites > 0 {
+		l.concurrentWrites = make(chan struct{}, concurrentWrites)
+		for i := 0; i < concurrentWrites; i++ {
+			l.concurrentWrites <- struct{}{}
+		}
+	}
+	return &l
+}
+
+// startTLSServer starts a local TLS server for testing Connect/openConnection.
+// Returns the server address and a client tls.Config that trusts the server's cert.
+func startTLSServer(t *testing.T) (addr string, clientConfig *tls.Config) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Accept connections in the background. Track them so we can close them
+	// on cleanup — but keep them open during the test so the TLS handshake
+	// completes on the client side.
+	var (
+		connMu sync.Mutex
+		conns  []net.Conn
+	)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			connMu.Lock()
+			conns = append(conns, conn)
+			connMu.Unlock()
+			// Complete the TLS handshake so the client's tls.Dial returns.
+			if tlsConn, ok := conn.(*tls.Conn); ok {
+				_ = tlsConn.Handshake()
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		listener.Close()
+		connMu.Lock()
+		for _, c := range conns {
+			c.Close()
+		}
+		connMu.Unlock()
+	})
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(certPEM)
+
+	return listener.Addr().String(), &tls.Config{RootCAs: pool}
+}
+
+func TestConnectOpensConnection(t *testing.T) {
+	addr, clientConfig := startTLSServer(t)
+
+	// Connect uses a default tls.Config that won't trust our self-signed
+	// cert, so we set up the logger manually and call openConnection — the
+	// same code path Connect takes.
+	le := newEmptyLogger(addr, "", 0)
+	le.tlsConfig = clientConfig
+
+	if err := le.openConnection(); err != nil {
+		t.Fatal(err)
+	}
 	defer le.Close()
 
 	if le.conn == nil {
-		t.Fail()
-	}
-
-	if le.conn == nil {
-		t.Fail()
+		t.Fatal("expected conn to be non-nil after openConnection")
 	}
 }
 
 func TestConnectSetsToken(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer le.Close()
+	le := newTestLogger("myToken", 0)
 
 	if le.token != "myToken" {
-		t.Fail()
+		t.Fatalf("expected token 'myToken', got '%s'", le.token)
 	}
 }
 
 func TestCloseClosesConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("", 0)
 
 	le.Close()
 
 	if le.conn != nil {
-		t.Fail()
+		t.Fatal("expected conn to be nil after Close")
 	}
 }
 
 func TestOpenConnectionOpensConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
+	addr, clientConfig := startTLSServer(t)
+
+	le := newEmptyLogger(addr, "", 0)
+	le.tlsConfig = clientConfig
+
+	if err := le.openConnection(); err != nil {
 		t.Fatal(err)
 	}
-
 	defer le.Close()
 
-	le.openConnection()
-
 	if le.conn == nil {
-		t.Fail()
+		t.Fatal("expected conn to be non-nil after openConnection")
 	}
 }
 
 func TestEnsureOpenConnectionDoesNothingOnOpenConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("", 0)
+	existingConn := le.conn
 
-	defer le.Close()
-	old := &le.conn
+	le.ensureOpenConnection()
 
-	le.openConnection()
-
-	if old != &le.conn {
-		t.Fail()
+	if le.conn != existingConn {
+		t.Fatal("expected ensureOpenConnection to keep existing conn")
 	}
 }
 
 func TestEnsureOpenConnectionCreatesNewConnection(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
+	addr, clientConfig := startTLSServer(t)
+
+	le := newEmptyLogger(addr, "", 0)
+	le.tlsConfig = clientConfig
+	// conn starts nil
+	if le.conn != nil {
+		t.Fatal("expected conn to start nil")
 	}
 
+	if err := le.ensureOpenConnection(); err != nil {
+		t.Fatal(err)
+	}
 	defer le.Close()
 
-	le.openConnection()
-
 	if le.conn == nil {
-		t.Fail()
+		t.Fatal("expected conn to be non-nil after ensureOpenConnection")
 	}
 }
 
@@ -141,11 +237,7 @@ func TestSetPrefixSetsPrefix(t *testing.T) {
 }
 
 func TestLoggerImplementsWriterInterface(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	le := newTestLogger("myToken", 0)
 	defer le.Close()
 
 	// the test will fail to compile if Logger doesn't implement io.Writer
@@ -153,15 +245,11 @@ func TestLoggerImplementsWriterInterface(t *testing.T) {
 }
 
 func TestReplaceNewline(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("myToken", 0)
+	defer le.Close()
 
 	le._testWaitForWrite = &sync.WaitGroup{}
 	le._testWaitForWrite.Add(1)
-
-	defer le.Close()
 
 	le.Println("1\n2\n3")
 
@@ -173,15 +261,11 @@ func TestReplaceNewline(t *testing.T) {
 }
 
 func TestAddNewline(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("myToken", 0)
+	defer le.Close()
 
 	le._testWaitForWrite = &sync.WaitGroup{}
 	le._testWaitForWrite.Add(1)
-
-	defer le.Close()
 
 	le.Print("123")
 
@@ -203,15 +287,11 @@ func TestAddNewline(t *testing.T) {
 }
 
 func TestCanSendMoreThan64k(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("myToken", 0)
+	defer le.Close()
 
 	le._testWaitForWrite = &sync.WaitGroup{}
 	le._testWaitForWrite.Add(3) // 3 because we need to write 3 times since it exceeds the limit (64k)
-
-	defer le.Close()
 
 	longBytes := make([]byte, 140000)
 	for i := 0; i < 140000; i++ {
@@ -231,10 +311,9 @@ func TestCanSendMoreThan64k(t *testing.T) {
 }
 
 func TestTimeoutWrites(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 0, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("myToken", 0)
+	defer le.Close()
+
 	timedoutCount := 0
 	le._testTimedoutWrite = func() {
 		timedoutCount++
@@ -242,8 +321,6 @@ func TestTimeoutWrites(t *testing.T) {
 
 	le._testWaitForWrite = &sync.WaitGroup{}
 	le._testWaitForWrite.Add(1)
-
-	defer le.Close()
 
 	b := make([]byte, 1000)
 	for i := 0; i < 1000; i++ {
@@ -269,10 +346,9 @@ func TestTimeoutWrites(t *testing.T) {
 }
 
 func TestLimitedConcurrentWrites(t *testing.T) {
-	le, err := Connect("data.logentries.com:443", "myToken", 3, io.Discard, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	le := newTestLogger("myToken", 3)
+	defer le.Close()
+
 	timedoutCount := 0
 	le._testTimedoutWrite = func() {
 		timedoutCount++
@@ -280,8 +356,6 @@ func TestLimitedConcurrentWrites(t *testing.T) {
 
 	le._testWaitForWrite = &sync.WaitGroup{}
 	le._testWaitForWrite.Add(1)
-
-	defer le.Close()
 
 	b := make([]byte, 1000)
 	for i := 0; i < 1000; i++ {
@@ -383,28 +457,3 @@ func ExampleLogger_write() {
 
 	fmt.Fprintln(le, "another test message")
 }
-
-// func BenchmarkMakeBuf(b *testing.B) {
-// 	le := Logger{token: "token"}
-
-// 	for i := 0; i < b.N; i++ {
-// 		le.makeBuf([]byte("test\nstring\n"))
-// 	}
-// }
-
-// func BenchmarkMakeBufWithoutNewlineSuffix(b *testing.B) {
-// 	le := Logger{token: "token"}
-
-// 	for i := 0; i < b.N; i++ {
-// 		le.makeBuf([]byte("test\nstring"))
-// 	}
-// }
-
-// func BenchmarkMakeBufWithPrefix(b *testing.B) {
-// 	le := Logger{token: "token"}
-// 	le.SetPrefix("prefix")
-
-// 	for i := 0; i < b.N; i++ {
-// 		le.makeBuf([]byte("test\nstring\n"))
-// 	}
-// }


### PR DESCRIPTION
## Summary

- Remove `isOpenConnection` (read-probe + 15-minute forced reconnect) which caused a connection storm after 15 minutes of uptime because `lastRefreshAt` was never updated on reconnect.
- Replace with the same pattern used by Rapid7's official clients (r7insight_node, r7insight_python, r7insight_java): just write, and if it fails, nil the conn and reconnect on the next attempt.

## Test plan

- [ ] Deploy to a long-running service and verify connection count is stable (no longer spikes after 15 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)